### PR TITLE
[DOC-41] Consolidate responses

### DIFF
--- a/html/modules/custom/docstore/docstore.routing.yml
+++ b/html/modules/custom/docstore/docstore.routing.yml
@@ -102,7 +102,7 @@ docstore_document_create_type:
     docstore_crud: 'C'
     docstore_access_level: 'A'
 docstore_document_get_type:
-  path: '/api/v1/types/{node_type}'
+  path: '/api/v1/types/{type}'
   defaults:
     _controller: 'docstore.doctype_controller:getDocumentType'
     _title: 'Get document type'
@@ -114,7 +114,7 @@ docstore_document_get_type:
     docstore_crud: 'R'
     docstore_access_level: 'A'
 docstore_document_update_type:
-  path: '/api/v1/types/{node_type}'
+  path: '/api/v1/types/{type}'
   defaults:
     _controller: 'docstore.doctype_controller:updateDocumentType'
     _title: 'Update document type'
@@ -126,7 +126,7 @@ docstore_document_update_type:
     docstore_crud: 'R'
     docstore_access_level: 'A'
 docstore_document_delete_type:
-  path: '/api/v1/types/{node_type}'
+  path: '/api/v1/types/{type}'
   defaults:
     _controller: 'docstore.doctype_controller:deleteDocumentType'
     _title: 'Delete document type'
@@ -140,7 +140,7 @@ docstore_document_delete_type:
 
 # Document fields
 docstore_document_get_fields:
-  path: '/api/v1/types/{node_type}/fields'
+  path: '/api/v1/types/{type}/fields'
   defaults:
     _controller: 'docstore.doctype_controller:getDocumentFields'
     _title: 'Get document fields'
@@ -152,7 +152,7 @@ docstore_document_get_fields:
     docstore_crud: 'R'
     docstore_access_level: 'A'
 docstore_document_create_fields:
-  path: '/api/v1/types/{node_type}/fields'
+  path: '/api/v1/types/{type}/fields'
   defaults:
     _controller: 'docstore.doctype_controller:createDocumentField'
     _title: 'Create document field'
@@ -164,7 +164,7 @@ docstore_document_create_fields:
     docstore_crud: 'C'
     docstore_access_level: 'A'
 docstore_document_get_field:
-  path: '/api/v1/types/{node_type}/fields/{id}'
+  path: '/api/v1/types/{type}/fields/{id}'
   defaults:
     _controller: 'docstore.doctype_controller:getDocumentField'
     _title: 'Get document field'
@@ -176,7 +176,7 @@ docstore_document_get_field:
     docstore_crud: 'R'
     docstore_access_level: 'A'
 docstore_document_update_field:
-  path: '/api/v1/types/{node_type}/fields/{id}'
+  path: '/api/v1/types/{type}/fields/{id}'
   defaults:
     _controller: 'docstore.doctype_controller:updateDocumentField'
     _title: 'Update document field'
@@ -188,7 +188,7 @@ docstore_document_update_field:
     docstore_crud: 'R'
     docstore_access_level: 'A'
 docstore_document_delete_field:
-  path: '/api/v1/types/{node_type}/fields/{id}'
+  path: '/api/v1/types/{type}/fields/{id}'
   defaults:
     _controller: 'docstore.doctype_controller:deleteDocumentField'
     _title: 'Delete document field'

--- a/html/modules/custom/docstore/docstore.routing.yml
+++ b/html/modules/custom/docstore/docstore.routing.yml
@@ -760,6 +760,8 @@ docstore_download_private_media:
   methods: [GET]
   requirements:
     _access: 'TRUE'
+  options:
+    docstore_crud: 'R'
 
 # Download private file
 docstore_download_private_file:
@@ -770,3 +772,5 @@ docstore_download_private_file:
   methods: [GET]
   requirements:
     _access: 'TRUE'
+  options:
+    docstore_crud: 'R'

--- a/html/modules/custom/docstore/src/Controller/DocumentController.php
+++ b/html/modules/custom/docstore/src/Controller/DocumentController.php
@@ -6,8 +6,6 @@ use Drupal\Component\Transliteration\TransliterationInterface;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Component\Uuid\Uuid;
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Cache\CacheableJsonResponse;
-use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Database\Connection;
@@ -22,14 +20,13 @@ use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\docstore\DocumentTypeTrait;
 use Drupal\docstore\MetadataTrait;
 use Drupal\docstore\ProviderTrait;
+use Drupal\docstore\ResourceTrait;
 use Drupal\entity_usage\EntityUsage;
 use Drupal\file\Entity\File;
 use Drupal\file\FileUsage\FileUsageInterface;
 use Drupal\media\Entity\Media;
 use Drupal\node\Entity\Node;
 use Drupal\user\Entity\User;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -42,6 +39,7 @@ class DocumentController extends ControllerBase {
   use DocumentTypeTrait;
   use MetadataTrait;
   use ProviderTrait;
+  use ResourceTrait;
 
   /**
    * The config.
@@ -162,44 +160,31 @@ class DocumentController extends ControllerBase {
    */
   public function createDocument($type, Request $request) {
     // Check if type is allowed.
-    $node_type = $this->typeAllowed($type, 'write');
+    $type = $this->typeAllowed($type, 'write');
 
     // Get provider.
     $provider = $this->requireProvider();
 
     // Parse JSON.
-    $params = json_decode($request->getContent(), TRUE);
-    if (empty($params) || !is_array($params)) {
-      throw new BadRequestHttpException('You have to pass a JSON object');
-    }
+    $params = $this->getRequestContent($request);
 
     // Create document.
-    $document = $this->createDocumentForProvider($node_type, $params, $provider);
+    $document = $this->createDocumentForProvider($type, $params, $provider);
 
     $data = [
-      'message' => strtr('@type created', ['@type' => $this->getNodeTypeLabel($node_type)]),
+      'message' => strtr('@type created', ['@type' => $this->getNodeTypeLabel($type)]),
       'uuid' => $document->uuid(),
     ];
 
-    $response = new JsonResponse($data);
-    $response->setStatusCode(201);
-
-    return $response;
+    return $this->createJsonResponse($data, 201);
   }
 
   /**
    * Create document for provider.
    */
   protected function createDocumentForProvider($type, $params, $provider) {
-    /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->entityTypeManager->getStorage('node_type')->load($type);
-
-    // Check if provider can create terms.
-    if ($node_type->getThirdPartySetting('docstore', 'provider_uuid') !== $provider->uuid) {
-      if (!$node_type->getThirdPartySetting('docstore', 'content_allowed', FALSE)) {
-        throw new \Exception(strtr('You are not allowed to create new documents in @node_type', ['@node_type' => $node_type->label()]));
-      }
-    }
+    // Check if provider can create documents.
+    $this->providerCanCreateUpdateDelete($this->getNodeType($type));
 
     // Check required fields.
     if (empty($params['title'])) {
@@ -332,16 +317,13 @@ class DocumentController extends ControllerBase {
    */
   public function createDocumentInBulk($type, Request $request) {
     // Check if type is allowed.
-    $node_type = $this->typeAllowed($type, 'write');
+    $type = $this->typeAllowed($type, 'write');
 
     // Get provider.
     $provider = $this->requireProvider();
 
     // Parse JSON.
-    $params = json_decode($request->getContent(), TRUE);
-    if (empty($params) || !is_array($params)) {
-      throw new BadRequestHttpException('You have to pass a JSON object');
-    }
+    $params = $this->getRequestContent($request);
 
     if (empty($params['documents'])) {
       throw new BadRequestHttpException('documents is required');
@@ -353,18 +335,15 @@ class DocumentController extends ControllerBase {
       $document['author'] = $params['author'];
 
       // Create document.
-      $doc = $this->createDocumentForProvider($node_type, $document, $provider);
+      $doc = $this->createDocumentForProvider($type, $document, $provider);
 
       $data[] = [
-        'message' => strtr('@type created', ['@type' => $this->getNodeTypeLabel($node_type)]),
+        'message' => strtr('@type created', ['@type' => $this->getNodeTypeLabel($type)]),
         'uuid' => $doc->uuid(),
       ];
     }
 
-    $response = new JsonResponse($data);
-    $response->setStatusCode(201);
-
-    return $response;
+    return $this->createJsonResponse($data, 201);
   }
 
   /**
@@ -403,18 +382,10 @@ class DocumentController extends ControllerBase {
     }
 
     // Parse JSON.
-    $params = json_decode($request->getContent(), TRUE);
-    if (empty($params) || !is_array($params)) {
-      throw new BadRequestHttpException('You have to pass a JSON object');
-    }
+    $params = $this->getRequestContent($request);
 
-    // Get provider.
-    $provider = $this->requireProvider();
-
-    // Provider can only update own document.
-    if ($document->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('Document is not owned by you');
-    }
+    // A document can only be updated by its owner.
+    $this->providerIsOwner($document);
 
     // Check required fields.
     if ($request->getMethod() === 'PUT') {
@@ -509,8 +480,10 @@ class DocumentController extends ControllerBase {
     $document->setRevisionCreationTime(time());
 
     /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->entityTypeManager->getStorage('node_type')->load($type);
+    $node_type = $this->getNodeType($type);
 
+    // Load provider.
+    $provider = $this->getProvider();
     if ($node_type->isNewRevision() || $params['new_revision'] ?? FALSE) {
       $document->revision_log = 'Updated';
       if (isset($params['revision_log'])) {
@@ -548,14 +521,11 @@ class DocumentController extends ControllerBase {
     Cache::invalidateTags(['documents']);
 
     // Add cache tags.
-    $cache_tags['#cache'] = [
+    $cache = [
       'tags' => $document->getCacheTags(),
     ];
 
-    $response = new CacheableJsonResponse($data);
-    $response->addCacheableDependency(CacheableMetadata::createFromRenderArray($cache_tags));
-
-    return $response;
+    return $this->createCacheableJsonResponse($cache, $data, 200);
   }
 
   /**
@@ -563,21 +533,16 @@ class DocumentController extends ControllerBase {
    */
   public function deleteDocument($type, $id, Request $request) {
     // Check if type is allowed.
-    $node_type = $this->typeAllowed($type, 'write');
+    $type = $this->typeAllowed($type, 'write');
 
     // Load document.
     $document = $this->loadDocument($id);
 
-    // Get provider.
-    $provider = $this->requireProvider();
-
-    // Provider can only update own document.
-    if ($document->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('Document is not owned by you');
-    }
+    // A document can only be deleted by its owner.
+    $this->providerIsOwner($document);
 
     $data = [
-      'message' => strtr('@type deleted', ['@type' => $this->getNodeTypeLabel($node_type)]),
+      'message' => strtr('@type deleted', ['@type' => $this->getNodeTypeLabel($type)]),
       'uuid' => $document->uuid(),
     ];
 
@@ -586,9 +551,7 @@ class DocumentController extends ControllerBase {
     // Invalidate cache.
     Cache::invalidateTags(['documents']);
 
-    $response = new JsonResponse($data);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -596,13 +559,10 @@ class DocumentController extends ControllerBase {
    */
   public function publishDocumentRevision($type, $id, $vid, Request $request) {
     // Check if type is allowed.
-    $node_type = $this->typeAllowed($type, 'write');
+    $type = $this->typeAllowed($type, 'write');
 
     // Parse JSON.
-    $params = json_decode($request->getContent(), TRUE);
-    if (empty($params) || !is_array($params)) {
-      throw new BadRequestHttpException('You have to pass a JSON object');
-    }
+    $params = $this->getRequestContent($request);
 
     // Get provider.
     $provider = $this->requireProvider();
@@ -624,17 +584,15 @@ class DocumentController extends ControllerBase {
     /** @var \Drupal\node\Entity\Node $document */
     $document = $this->entityTypeManager->getStorage('node')->loadRevision($vid);
 
-    // Provider can only update own document.
-    if ($document->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('Document is not owned by you');
-    }
+    // A document can only be updated by its owner.
+    $this->providerIsOwner($document);
 
     if ($document->uuid() !== $id) {
-      throw new BadRequestHttpException('Revision not found');
+      throw new NotFoundHttpException('Revision not found');
     }
 
-    if ($document->bundle() !== $node_type) {
-      throw new BadRequestHttpException('Wrong node type');
+    if ($document->bundle() !== $type) {
+      throw new BadRequestHttpException('Wrong document type');
     }
 
     if (!$document->isDefaultRevision()) {
@@ -651,19 +609,16 @@ class DocumentController extends ControllerBase {
     }
 
     $data = [
-      'message' => strtr('@type updated', ['@type' => $this->getNodeTypeLabel($node_type)]),
+      'message' => strtr('@type updated', ['@type' => $this->getNodeTypeLabel($type)]),
       'uuid' => $document->uuid(),
     ];
 
     // Add cache tags.
-    $cache_tags['#cache'] = [
+    $cache = [
       'tags' => $document->getCacheTags(),
     ];
 
-    $response = new CacheableJsonResponse($data);
-    $response->addCacheableDependency(CacheableMetadata::createFromRenderArray($cache_tags));
-
-    return $response;
+    return $this->createCacheableJsonResponse($cache, $data, 200);
   }
 
   /**
@@ -690,9 +645,7 @@ class DocumentController extends ControllerBase {
       ];
     }
 
-    $response = new JsonResponse($data);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -708,13 +661,9 @@ class DocumentController extends ControllerBase {
     /** @var \Drupal\media\Entity\File $file */
     $file = $this->entityTypeManager->getStorage('file')->load($media->getSource()->getSourceFieldValue($media));
 
-    // Get provider.
-    $provider = $this->getProvider();
-
-    // Provider can only get own private files.
-    $private = StreamWrapperManager::getScheme($file->getFileUri()) === 'private';
-    if ($private && $file->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('Media is not owned by you');
+    // If the file is private check if the provider is its owner.
+    if (StreamWrapperManager::getScheme($file->getFileUri()) === 'private') {
+      $this->providerIsOwner($file);
     }
 
     $data = [
@@ -737,9 +686,7 @@ class DocumentController extends ControllerBase {
 
     $data['revisions'] = array_keys($revisions);
 
-    $response = new JsonResponse($data);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -765,13 +712,9 @@ class DocumentController extends ControllerBase {
     /** @var \Drupal\media\Entity\File $file */
     $file = $this->entityTypeManager->getStorage('file')->load($revision->getSource()->getSourceFieldValue($revision));
 
-    // Get provider.
-    $provider = $this->getProvider();
-
-    // Provider can only get own private files.
-    $private = StreamWrapperManager::getScheme($file->getFileUri()) === 'private';
-    if ($private && $file->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('File is not owned by you');
+    // If the file is private check if the provider is its owner.
+    if (StreamWrapperManager::getScheme($file->getFileUri()) === 'private') {
+      $this->providerIsOwner($file);
     }
 
     $data = [
@@ -784,9 +727,7 @@ class DocumentController extends ControllerBase {
       'uri' => $request->getSchemeAndHttpHost() . $file->createFileUrl(),
     ];
 
-    $response = new JsonResponse($data);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -802,13 +743,9 @@ class DocumentController extends ControllerBase {
     /** @var \Drupal\media\Entity\File $file */
     $file = $this->entityTypeManager->getStorage('file')->load($media->getSource()->getSourceFieldValue($media));
 
-    // Get provider.
-    $provider = $this->getProvider();
-
-    // Provider can only get own private files.
-    $private = StreamWrapperManager::getScheme($file->getFileUri()) === 'private';
-    if ($private && $file->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('Media is not owned by you');
+    // If the file is private check if the provider is its owner.
+    if (StreamWrapperManager::getScheme($file->getFileUri()) === 'private') {
+      $this->providerIsOwner($file);
     }
 
     $headers = [
@@ -817,7 +754,7 @@ class DocumentController extends ControllerBase {
       'Cache-Control' => 'private',
     ];
 
-    return new BinaryFileResponse($file->getFileUri(), 200, $headers);
+    return $this->createBinaryFileResponse($file->getFileUri(), 200, $headers);
   }
 
   /**
@@ -827,13 +764,13 @@ class DocumentController extends ControllerBase {
     /** @var \Drupal\media\Entity\Media $media */
     $media = $this->entityRepository->loadEntityByUuid('media', $id);
     if (!$media) {
-      throw new BadRequestHttpException('Media does not exist');
+      throw new NotFoundHttpException('Media does not exist');
     }
 
     /** @var \Drupal\media\Entity\Media $revision */
     $revision = $this->entityTypeManager->getStorage('media')->loadRevision($vid);
     if (!$revision) {
-      throw new BadRequestHttpException('Revision does not exist');
+      throw new NotFoundHttpException('Revision does not exist');
     }
 
     if ($revision->id() !== $media->id()) {
@@ -843,13 +780,9 @@ class DocumentController extends ControllerBase {
     /** @var \Drupal\media\Entity\File $file */
     $file = $this->entityTypeManager->getStorage('file')->load($revision->getSource()->getSourceFieldValue($revision));
 
-    // Get provider.
-    $provider = $this->requireProvider();
-
-    // Provider can only get own private files.
-    $private = StreamWrapperManager::getScheme($file->getFileUri()) === 'private';
-    if ($private && $file->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('File is not owned by you');
+    // If the file is private check if the provider is its owner.
+    if (StreamWrapperManager::getScheme($file->getFileUri()) === 'private') {
+      $this->providerIsOwner($file);
     }
 
     $headers = [
@@ -858,7 +791,7 @@ class DocumentController extends ControllerBase {
       'Cache-Control' => 'private',
     ];
 
-    return new BinaryFileResponse($file->getFileUri(), 200, $headers);
+    return $this->createBinaryFileResponse($file->getFileUri(), 200, $headers);
   }
 
   /**
@@ -870,6 +803,7 @@ class DocumentController extends ControllerBase {
 
     // Load provider.
     $provider = $this->getProvider();
+    $provider_id = (!$provider || $provider->isAnonymous()) ? FALSE : $provider->id();
 
     /** @var \Drupal\file\Entity\File $file */
     foreach ($files as $file) {
@@ -884,7 +818,7 @@ class DocumentController extends ControllerBase {
       // Hide private files, unless it's the owner.
       if (StreamWrapperManager::getScheme($file->getFileUri()) === 'private') {
         $file_record['private'] = TRUE;
-        if ($provider->isAnonymous() || $file->getOwnerId() !== $provider->uuid()) {
+        if ($file->getOwnerId() !== $provider_id) {
           unset($file_record['uri']);
         }
       }
@@ -892,9 +826,7 @@ class DocumentController extends ControllerBase {
       $data[] = $file_record;
     }
 
-    $response = new JsonResponse($data);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -902,10 +834,7 @@ class DocumentController extends ControllerBase {
    */
   public function createFile(Request $request) {
     // Parse JSON.
-    $params = json_decode($request->getContent(), TRUE);
-    if (empty($params) || !is_array($params)) {
-      throw new BadRequestHttpException('You have to pass a JSON object');
-    }
+    $params = $this->getRequestContent($request);
 
     // Load provider.
     $provider = $this->requireProvider();
@@ -978,10 +907,7 @@ class DocumentController extends ControllerBase {
       'uuid' => $file->uuid(),
     ];
 
-    $response = new JsonResponse($data);
-    $response->setStatusCode(201);
-
-    return $response;
+    return $this->createJsonResponse($data, 201);
   }
 
   /**
@@ -991,16 +917,12 @@ class DocumentController extends ControllerBase {
     /** @var \Drupal\file\Entity\File $file */
     $file = $this->entityRepository->loadEntityByUuid('file', $id);
     if (!$file) {
-      throw new BadRequestHttpException('File does not exist');
+      throw new NotFoundHttpException('File does not exist');
     }
 
-    // Get provider.
-    $provider = $this->getProvider();
-
-    // Provider can only get own private files.
-    $private = StreamWrapperManager::getScheme($file->getFileUri()) === 'private';
-    if ($private && $file->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('File is not owned by you');
+    // If the file is private check if the provider is its owner.
+    if (StreamWrapperManager::getScheme($file->getFileUri()) === 'private') {
+      $this->providerIsOwner($file);
     }
 
     $data = [
@@ -1012,9 +934,7 @@ class DocumentController extends ControllerBase {
       'mimetype' => $file->getMimeType(),
     ];
 
-    $response = new JsonResponse($data);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -1022,24 +942,16 @@ class DocumentController extends ControllerBase {
    */
   public function updateFile($id, Request $request) {
     // Parse JSON.
-    $params = json_decode($request->getContent(), TRUE);
-    if (empty($params) || !is_array($params)) {
-      throw new BadRequestHttpException('You have to pass a JSON object');
-    }
+    $params = $this->getRequestContent($request);
 
     /** @var \Drupal\file\Entity\File $file */
     $file = $this->entityRepository->loadEntityByUuid('file', $id);
     if (!$file) {
-      throw new BadRequestHttpException('File does not exist');
+      throw new NotFoundHttpException('File does not exist');
     }
 
-    // Get provider.
-    $provider = $this->requireProvider();
-
-    // Provider can only update own files.
-    if ($file->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('File is not owned by you');
-    }
+    // A file can only be updated by its owner.
+    $this->providerIsOwner($file);
 
     // Filename is required.
     if (isset($params['filename']) && $params['filename'] !== $file->getFilename()) {
@@ -1071,9 +983,7 @@ class DocumentController extends ControllerBase {
       'message' => 'File updated',
     ];
 
-    $response = new JsonResponse($data);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -1086,13 +996,8 @@ class DocumentController extends ControllerBase {
       throw new BadRequestHttpException('File does not exist');
     }
 
-    // Get provider.
-    $provider = $this->requireProvider();
-
-    // Provider can only delete own files.
-    if ($file->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('File is not owned by you');
-    }
+    // A file can only be deleted by its owner.
+    $this->providerIsOwner($file);
 
     $usage_list = $this->fileUsage->listUsage($file);
     $usage_list = isset($usage_list['file']) ? $usage_list['file'] : [];
@@ -1106,9 +1011,7 @@ class DocumentController extends ControllerBase {
       'message' => 'File is deleted',
     ];
 
-    $response = new JsonResponse($data);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -1121,13 +1024,9 @@ class DocumentController extends ControllerBase {
       throw new BadRequestHttpException('File does not exist');
     }
 
-    // Get provider.
-    $provider = $this->requireProvider();
-
-    // Provider can only get own private files.
-    $private = StreamWrapperManager::getScheme($file->getFileUri()) === 'private';
-    if ($private && $file->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('File is not owned by you');
+    // If the file is private check if the provider is its owner.
+    if (StreamWrapperManager::getScheme($file->getFileUri()) === 'private') {
+      $this->providerIsOwner($file);
     }
 
     $data = [];
@@ -1141,9 +1040,7 @@ class DocumentController extends ControllerBase {
       }
     }
 
-    $response = new JsonResponse($data);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -1156,13 +1053,9 @@ class DocumentController extends ControllerBase {
       throw new BadRequestHttpException('File does not exist');
     }
 
-    // Get provider.
-    $provider = $this->requireProvider();
-
-    // Provider can only get own private files.
-    $private = StreamWrapperManager::getScheme($file->getFileUri()) === 'private';
-    if ($private && $file->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('File is not owned by you');
+    // If the file is private check if the provider is its owner.
+    if (StreamWrapperManager::getScheme($file->getFileUri()) === 'private') {
+      $this->providerIsOwner($file);
     }
 
     $headers = [
@@ -1171,7 +1064,7 @@ class DocumentController extends ControllerBase {
       'Cache-Control' => 'private',
     ];
 
-    return new BinaryFileResponse($file->getFileUri(), 200, $headers);
+    return $this->createBinaryFileResponse($file->getFileUri(), 200, $headers);
   }
 
   /**
@@ -1181,17 +1074,16 @@ class DocumentController extends ControllerBase {
     /** @var \Drupal\file\Entity\File $file */
     $file = $this->entityRepository->loadEntityByUuid('file', $id);
     if (!$file) {
-      throw new BadRequestHttpException('File does not exist');
+      throw new NotFoundHttpException('File does not exist');
     }
 
     // Get provider.
     $provider = $this->requireProvider();
 
-    // Provider can only update own files.
-    if ($file->getOwnerId() !== $provider->id()) {
-      throw new BadRequestHttpException('File is not owned by you');
-    }
+    // A file can only be deleted by its owner.
+    $this->providerIsOwner($file);
 
+    // @todo add some validation.
     $this->saveFileToDisk($file, $request->getContent(), $provider, TRUE);
 
     $data = [
@@ -1199,10 +1091,7 @@ class DocumentController extends ControllerBase {
       'uuid' => $file->uuid(),
     ];
 
-    $response = new JsonResponse($data);
-    $response->setStatusCode(201);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -1388,23 +1277,6 @@ class DocumentController extends ControllerBase {
   }
 
   /**
-   * Get allowed endpoints.
-   */
-  protected function typeAllowed($type, $mode = 'read') {
-    // Allow read operations on "any" endpoint.
-    if ($type === 'any' && $mode === 'read') {
-      return 'any';
-    }
-
-    // Allow read operations on "all" endpoint.
-    if ($type === 'all' && $mode === 'read') {
-      return 'any';
-    }
-
-    return $this->EndpointGetNodeType($type);
-  }
-
-  /**
    * Move file to private file system.
    */
   protected function moveFileToPrivate($file) {
@@ -1454,16 +1326,6 @@ class DocumentController extends ControllerBase {
     if (!file_move($file, $new_uri)) {
       throw new BadRequestHttpException('File could not be moved');
     }
-  }
-
-  /**
-   * Get node type label.
-   */
-  protected function getNodeTypeLabel($node_type) {
-    /** @var \Drupal\node\Entity\NodeType $type */
-    $type = $this->entityTypeManager->getStorage('node_type')->load($node_type);
-
-    return $type->label();
   }
 
 }

--- a/html/modules/custom/docstore/src/Controller/DownloadController.php
+++ b/html/modules/custom/docstore/src/Controller/DownloadController.php
@@ -6,13 +6,15 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Drupal\docstore\ResourceTrait;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Controller for files endpoint.
  */
 class DownloadController extends ControllerBase {
+
+  use ResourceTrait;
 
   /**
    * The entity manager service.
@@ -42,6 +44,8 @@ class DownloadController extends ControllerBase {
    * Download media file.
    *
    * Downloads the latest published version of the file.
+   *
+   * @todo throw a 404 Not Found instead?
    */
   public function downloadMedia($media_uuid, $provider_uuid, $hash, $filename) {
     /** @var \Drupal\media\Entity\Media $media */
@@ -74,13 +78,15 @@ class DownloadController extends ControllerBase {
       'Cache-Control' => 'private',
     ];
 
-    return new BinaryFileResponse($file->getFileUri(), 200, $headers);
+    return $this->createBinaryFileResponse($file->getFileUri(), 200, $headers);
   }
 
   /**
    * Download file.
    *
    * Downloads the file, regardless if it's the latest version or not.
+   *
+   * @todo throw a 404 Not Found instead?
    */
   public function downloadFile($file_uuid, $provider_uuid, $hash, $filename) {
     /** @var \Drupal\file\Entity\File $file */
@@ -110,7 +116,7 @@ class DownloadController extends ControllerBase {
       'Cache-Control' => 'private',
     ];
 
-    return new BinaryFileResponse($file->getFileUri(), 200, $headers);
+    return $this->createBinaryFileResponse($file->getFileUri(), 200, $headers);
   }
 
 }

--- a/html/modules/custom/docstore/src/Controller/ProviderController.php
+++ b/html/modules/custom/docstore/src/Controller/ProviderController.php
@@ -5,14 +5,17 @@ namespace Drupal\docstore\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Drupal\docstore\ProviderTrait;
+use Drupal\docstore\ResourceTrait;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * API controller for me endpoint.
  */
 class ProviderController extends ControllerBase {
+
+  use ProviderTrait;
+  use ResourceTrait;
 
   /**
    * The entity manager service.
@@ -52,9 +55,7 @@ class ProviderController extends ControllerBase {
       'shared_secret' => $provider->get('shared_secret')->value ?? '',
     ];
 
-    $response = new JsonResponse($data);
-
-    return $response;
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
@@ -62,7 +63,7 @@ class ProviderController extends ControllerBase {
    */
   public function updateInfo(Request $request) {
     // Parse JSON.
-    $params = json_decode($request->getContent(), TRUE);
+    $params = $this->getRequestContent($request);
 
     /** @var \Drupal\user\Entity\User $provider */
     $provider = $this->requireProvider();
@@ -76,24 +77,7 @@ class ProviderController extends ControllerBase {
       'message' => 'Provider updated',
     ];
 
-    $response = new JsonResponse($data);
-
-    return $response;
-  }
-
-  /**
-   * Get provider.
-   */
-  protected function requireProvider() {
-    /** @var Drupal\Core\Session\AccountProxy $current_user */
-    $current_user = $this->currentUser();
-    $provider = $current_user->getAccount();
-
-    if ($current_user->isAnonymous() || !$provider) {
-      throw new BadRequestHttpException('Provider is required');
-    }
-
-    return $provider;
+    return $this->createJsonResponse($data, 200);
   }
 
 }

--- a/html/modules/custom/docstore/src/Controller/WebhookController.php
+++ b/html/modules/custom/docstore/src/Controller/WebhookController.php
@@ -7,7 +7,8 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Drupal\docstore\ProviderTrait;
+use Drupal\docstore\ResourceTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
@@ -15,6 +16,9 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  * API controller for webhook endpoint.
  */
 class WebhookController extends ControllerBase {
+
+  use ProviderTrait;
+  use ResourceTrait;
 
   /**
    * The entity type manager.
@@ -47,7 +51,7 @@ class WebhookController extends ControllerBase {
     $data = [];
 
     // Get provider.
-    $provider = $this->getProvider();
+    $provider = $this->requireProvider();
 
     $query = $this->entityTypeManager->getStorage('webhook_config')->getQuery();
     $ids = $query->execute();
@@ -66,10 +70,12 @@ class WebhookController extends ControllerBase {
       }
     }
 
-    $response = new JsonResponse($data);
-    $response->setStatusCode(200);
+    // Add cache tags.
+    $cache = [
+      'tags' => ['webhooks'],
+    ];
 
-    return $response;
+    return $this->createCacheableJsonResponse($cache, $data, 200);
   }
 
   /**
@@ -77,7 +83,7 @@ class WebhookController extends ControllerBase {
    */
   public function createWebhook(Request $request) {
     // Parse JSON.
-    $params = json_decode($request->getContent(), TRUE);
+    $params = $this->getRequestContent($request);
 
     // Check required fields.
     if (empty($params['label'])) {
@@ -101,7 +107,7 @@ class WebhookController extends ControllerBase {
     }
 
     // Get provider.
-    $provider = $this->getProvider();
+    $provider = $this->requireProvider();
 
     // Construct Id.
     $id = $params['label'];
@@ -142,25 +148,18 @@ class WebhookController extends ControllerBase {
       'machine_name' => $id,
     ];
 
-    $response = new JsonResponse($data);
-    $response->setStatusCode(201);
-
-    return $response;
+    return $this->createJsonResponse($data, 201);
   }
 
   /**
    * Delete a hook.
    */
   public function deleteWebhook($id, Request $request) {
-    // Get provider.
-    $provider = $this->getProvider();
-
     // Check for duplicate.
     $webhook_config = WebhookConfig::load($id);
 
-    if ($webhook_config->getThirdPartySetting('docstore', 'base_provider_uuid') !== $provider->uuid()) {
-      throw new BadRequestHttpException('Webhook is not owned by you');
-    }
+    // A webhook can only be deleted by its owner.
+    $this->providerIsOwner($webhook_config, 'base_provider_uuid');
 
     $webhook_config->delete();
 
@@ -171,24 +170,7 @@ class WebhookController extends ControllerBase {
     // Invalidate cache.
     Cache::invalidateTags(['webhooks']);
 
-    $response = new JsonResponse($data);
-
-    return $response;
-  }
-
-  /**
-   * Get provider.
-   */
-  protected function getProvider() {
-    /** @var Drupal\Core\Session\AccountProxy $current_user */
-    $current_user = $this->currentUser();
-    $provider = $current_user->getAccount();
-
-    if (!$provider) {
-      throw new BadRequestHttpException('Provider is required');
-    }
-
-    return $provider;
+    return $this->createJsonResponse($data, 200);
   }
 
 }

--- a/html/modules/custom/docstore/src/Controller/WebhookController.php
+++ b/html/modules/custom/docstore/src/Controller/WebhookController.php
@@ -72,6 +72,7 @@ class WebhookController extends ControllerBase {
 
     // Add cache tags.
     $cache = [
+      'contexts' => ['user'],
       'tags' => ['webhooks'],
     ];
 

--- a/html/modules/custom/docstore/src/MetadataTrait.php
+++ b/html/modules/custom/docstore/src/MetadataTrait.php
@@ -4,6 +4,7 @@ namespace Drupal\docstore;
 
 use Drupal\field\Entity\FieldConfig;
 use Drupal\docstore\Controller\VocabularyController;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\user\Entity\User;
@@ -335,55 +336,104 @@ trait MetadataTrait {
   }
 
   /**
-   * Check if user has access to the field.
+   * Check if a provider has access to the field.
+   *
+   * @param string $field_name
+   *   Field name.
+   * @param string $bundle
+   *   Entity bundle (vocabulary or node type).
+   * @param string $entity_type
+   *   Entity type (term, taxonomy_term or node).
+   * @param \Drupal\Core\Session\AccountInterface $provider
+   *   Provider.
+   *
+   * @return bool
+   *   Whether the provider can use the field or not.
+   *
+   * @throw \Exception
+   *   Generic execption when the field doesn't exist.
+   *
+   * @todo review the exception and make that more generic, for example if we
+   * want to allow metadata on providers or files.
+   *
+   * @todo review if this shouldn't be moved to the ProviderTrait instead to
+   * go with the other `providerCan` methods.
    */
-  protected function providerCanUseField($field_name, $type, $entity_type, $provider) {
-    // Use real entity type.
-    if ($entity_type === 'term') {
-      $entity_type = 'taxonomy_term';
+  protected function providerCanUseField($field_name, $bundle, $entity_type, AccountInterface $provider) {
+    switch ($entity_type) {
+      case 'term':
+      case 'taxonomy_term':
+        // Use real entity type.
+        $entity_type = 'taxonomy_term';
+
+        $public_fields = [
+          'default_langcode',
+          'description',
+          'langcode',
+          'name',
+          'revision_default',
+          'revision_translation_affected',
+          'status',
+          'uuid',
+        ];
+        break;
+
+      case 'node':
+        $public_fields = [
+          'boost_document',
+          'changed',
+          'created',
+          'langcode',
+          'provider',
+          'published',
+          'rendered_item',
+          'search_api_id',
+          'search_api_relevance',
+          'title',
+          'type',
+          'uuid',
+          'vid',
+        ];
+        break;
     }
 
     static $cache = [];
 
-    if (isset($cache[$entity_type][$type][$field_name][$provider->id])) {
-      return $cache[$entity_type][$type][$field_name][$provider->id];
+    if (isset($cache[$entity_type][$bundle][$field_name][$provider->id()])) {
+      return $cache[$entity_type][$bundle][$field_name][$provider->id()];
     }
 
-    $public_fields = [
-      'uuid',
-      'langcode',
-      'status',
-      'name',
-      'description',
-      'default_langcode',
-      'revision_default',
-      'revision_translation_affected',
-    ];
-
+    // Public fields are usable by any provider.
     if (in_array($field_name, $public_fields)) {
-      $cache[$entity_type][$type][$field_name][$provider->id] = TRUE;
-      return $cache[$entity_type][$type][$field_name][$provider->id];
+      $cache[$entity_type][$bundle][$field_name][$provider->id()] = TRUE;
+      return TRUE;
     }
 
-    $field_config = FieldConfig::loadByName($entity_type, $type, $field_name);
+    // Check if the field exists and get its configuration.
+    $field_config = FieldConfig::loadByName($entity_type, $bundle, $field_name);
     if (!$field_config) {
+      // @todo review what type of exception to send.
       throw new \Exception(strtr('Field @field does not exist', [
         '@field' => $field_name,
       ]));
     }
 
+    // Check if the given provider is the provider of the field.
     if (!$provider->isAnonymous() && $field_config->getThirdPartySetting('docstore', 'provider_uuid') === $provider->uuid()) {
-      $cache[$entity_type][$type][$field_name][$provider->id] = TRUE;
-      return $cache[$entity_type][$type][$field_name][$provider->id];
+      $cache[$entity_type][$bundle][$field_name][$provider->id()] = TRUE;
+      return TRUE;
     }
 
+    // Otherwise check if the field is not private, in which case any provider
+    // can access the field.
     if (!$field_config->getThirdPartySetting('docstore', 'private', FALSE)) {
-      $cache[$entity_type][$type][$field_name][$provider->id] = TRUE;
-      return $cache[$entity_type][$type][$field_name][$provider->id];
+      $cache[$entity_type][$bundle][$field_name][$provider->id()] = TRUE;
+      return TRUE;
     }
 
-    $cache[$entity_type][$type][$field_name][$provider->id] = FALSE;
-    return $cache[$entity_type][$type][$field_name][$provider->id];
+    // Otherwise deny access to the field.
+    $cache[$entity_type][$bundle][$field_name][$provider->id()] = FALSE;
+    return FALSE;
   }
 
 }

--- a/html/modules/custom/docstore/src/ProviderTrait.php
+++ b/html/modules/custom/docstore/src/ProviderTrait.php
@@ -2,6 +2,10 @@
 
 namespace Drupal\docstore;
 
+// @todo consider creating a docstore `Resource`?
+use Drupal\Core\Entity\EntityInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
 /**
  * Provider related functions.
  */
@@ -24,17 +28,146 @@ trait ProviderTrait {
   /**
    * Require provider.
    *
-   * @return \Drupal\user_bundle\Entity\TypedUser|false
+   * @return \Drupal\user_bundle\Entity\TypedUser
    *   The provider if found.
+   *
+   * @throw \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+   *   403 Access Denied if no valid provider is found.
    */
   protected function requireProvider() {
     $provider = $this->getProvider();
 
     if (!$provider || $provider->isAnonymous()) {
-      throw new \Exception('Provider is required');
+      throw new AccessDeniedHttpException('Provider is required');
     }
 
     return $provider;
+  }
+
+  /**
+   * Check if provider can read content.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $resource
+   *   Docstore resource (node type or vocabulary).
+   *
+   * @return bool
+   *   TRUE if the provider is allowed to create content for the resource.
+   *
+   * @throw \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+   *   403 Access Denied if no valid provider is found or if the provider
+   *   doesn't have read access to the resource.
+   */
+  protected function providerCanRead(EntityInterface $resource) {
+    // Shared resources are always readable.
+    if ($resource->getThirdPartySetting('docstore', 'shared')) {
+      return TRUE;
+    }
+
+    // Otherwise a provider is required.
+    $provider = $this->requireProvider();
+
+    // Check if the current provider is the provider of the resource.
+    if ($type->getThirdPartySetting('docstore', 'provider_uuid') === $provider->uuid()) {
+      return TRUE;
+    }
+
+    throw new AccessDeniedHttpException('You do not have access to read @label resources', [
+      '@label' => $resource->label(),
+    ]);
+  }
+
+  /**
+   * Check if the provider is allowed to create content for the resource.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $resource
+   *   Docstore resource (node type or vocabulary).
+   *
+   * @return bool
+   *   TRUE if the provider is allowed to create content for the resource.
+   *
+   * @throw \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+   *   403 Access Denied if no valid provider is found or if the provider
+   *   doesn't have create/update/delete access to the resource.
+   */
+  protected function providerCanCreateUpdateDelete(EntityInterface $resource) {
+    // A provider is required to create, update or delete a resource.
+    $provider = $this->requireProvider();
+
+    // Check if the current provider is the provider of the resource.
+    if ($resource->getThirdPartySetting('docstore', 'provider_uuid') == $provider->uuid()) {
+      return TRUE;
+    }
+
+    // Otherwise check if other providers are allowed to create, update or
+    // delete this type of resource.
+    if ($resource->getThirdPartySetting('docstore', 'content_allowed', FALSE)) {
+      return TRUE;
+    }
+
+    throw new AccessDeniedHttpException('You do not have access to create, update or delete @label resources', [
+      '@label' => $resource->label(),
+    ]);
+  }
+
+  /**
+   * Check if the provider is the owner of the resource.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $resource
+   *   Docstore resource (node, term, file etc.).
+   * @param string $check_type
+   *   Type of check to perform:
+   *   - owner_id: check the owner id against the current provider's id.
+   *   - provider_uuid: check the uuid of the resource's provider against
+   *     the current provider's uuid.
+   *   - base_provider_uuid: check the `base_provider_uuid` third party setting
+   *     against the current provider's uuid.
+   *
+   * @return bool
+   *   TRUE if the provider is the owner of the resource.
+   */
+  protected function providerIsOwner(EntityInterface $resource, $check_type = 'owner_id') {
+    $provider = $this->requireProvider();
+
+    switch ($resource->getEntityTypeId()) {
+      case 'node':
+        $type = 'Document';
+        break;
+
+      case 'taxonomy_term':
+        $type = 'Term';
+        break;
+
+      case 'webhook_config':
+        $type = 'Webhook';
+        break;
+
+      default:
+        $type = ucfirst($resource->getEntityTypeId());
+    }
+
+    $is_owner = FALSE;
+
+    switch ($check_type) {
+      case 'owner_id':
+        $is_owner = $resource->getOwnerId() === $provider->id();
+        break;
+
+      case 'provider_uuid':
+        $is_owner = $resource->provider_uuid->entity->uuid() === $provider->uuid();
+        break;
+
+      case 'base_provider_uuid':
+        $is_owner = $resource->getThirdPartySetting('docstore', 'base_provider_uuid') === $provider->uuid();
+        break;
+    }
+
+    if ($is_owner) {
+      return TRUE;
+    }
+
+    throw new AccessDeniedHttpException(strtr('@type is not owned by you', [
+      '@type' => $type,
+    ]));
   }
 
 }

--- a/html/modules/custom/docstore/src/ResourceTrait.php
+++ b/html/modules/custom/docstore/src/ResourceTrait.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\docstore;
+
+use Drupal\Core\Cache\CacheableJsonResponse;
+use Drupal\Core\Cache\CacheableMetadata;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Resource related functions.
+ */
+trait ResourceTrait {
+
+  /**
+   * Get the request content.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   API Request.
+   *
+   * @return array
+   *   Request content.
+   *
+   * @throw \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+   *   Throw a 400 when the request doesn't have a valid JSON content.
+   */
+  public function getRequestContent(Request $request) {
+    $content = json_decode($request->getContent(), TRUE);
+    if (empty($content) || !is_array($content)) {
+      throw new BadRequestHttpException('You have to pass a JSON object');
+    }
+    return $content;
+  }
+
+  /**
+   * Send a JSON response with the given data and status code.
+   *
+   * @param mixed $data
+   *   Response data.
+   * @param int $code
+   *   Status code.
+   * @param array $headers
+   *   Response headers.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   JSON response.
+   */
+  public function createJsonResponse($data = NULL, $code = 200, array $headers = []) {
+    $response = new JsonResponse($data, $code, $headers);
+    $response->setStatusCode($code);
+    return $response;
+  }
+
+  /**
+   * Send a cacheable JSON response with the given data and status code.
+   *
+   * @param array $cache
+   *   Array of cache data with the following optional keys: tags, contexts and
+   *   max-age.
+   * @param mixed $data
+   *   Response data.
+   * @param int $code
+   *   Status code.
+   * @param array $headers
+   *   Response headers.
+   *
+   * @return \Drupal\Core\Cache\CacheableJsonResponse
+   *   JSON response.
+   */
+  public function createCacheableJsonResponse(array $cache = [], $data = NULL, $code = 200, array $headers = []) {
+    $response = new CacheableJsonResponse($data, $code, $headers);
+    $response->addCacheableDependency(CacheableMetadata::createFromRenderArray([
+      '#cache' => $cache,
+    ]));
+    return $response;
+  }
+
+  /**
+   * Send a Binary response with the given data and status code.
+   *
+   * @param \SplFileInfo|string $file
+   *   The file to stream.
+   * @param int $code
+   *   Status code.
+   * @param array $headers
+   *   Response headers.
+   *
+   * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+   *   JSON response.
+   */
+  public function createBinaryFileResponse($file, $code = 200, array $headers = []) {
+    $response = new BinaryFileResponse($file, 200, $headers);
+    return $response;
+  }
+
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,6 +1,6 @@
 # Env vars
 DRUSH=${DRUSH:-"fin drush"}
-SILK=${SILK:-".silk"}
+SILK=${SILK:-"./silk"}
 HOST=${HOST:-"http://docstore.local.docksal"}
 API=${API:-"$HOST/api/v1"}
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,5 +1,6 @@
 # Env vars
 DRUSH=${DRUSH:-"fin drush"}
+SILK=${SILK:-".silk"}
 HOST=${HOST:-"http://docstore.local.docksal"}
 API=${API:-"$HOST/api/v1"}
 
@@ -10,19 +11,19 @@ $DRUSH cr
 # Add document type
 $DRUSH eval "docstore_create_node_type('document', 'documents')"
 
-./silk -test.v -silk.url $API silk_webhooks.md || exit 1;
-./silk -test.v -silk.url $API silk_vocabulary_crud.md || exit 1;
-./silk -test.v -silk.url $API silk_vocabulary_bulk.md || exit 1;
-./silk -test.v -silk.url $API silk_vocabulary_anon_cud.md || exit 1;
-./silk -test.v -silk.url $API silk_vocabulary_anon_r.md || exit 1;
-./silk -test.v -silk.url $API silk_document_types_crud.md || exit 1;
-./silk -test.v -silk.url $API silk_document_bulk.md || exit 1;
-./silk -test.v -silk.url $API silk_geofield.md || exit 1;
-./silk -test.v -silk.url $API silk_linkfield.md || exit 1;
-./silk -test.v -silk.url $API silk_child_terms.md || exit 1;
-./silk -test.v -silk.url $API silk_private.md || exit 1;
-./silk -test.v -silk.url $API silk_document_revisions.md || exit 1;
-./silk -test.v -silk.url $API silk_term_revisions.md || exit 1;
+$SILK -test.v -silk.url $API silk_webhooks.md || exit 1;
+$SILK -test.v -silk.url $API silk_vocabulary_crud.md || exit 1;
+$SILK -test.v -silk.url $API silk_vocabulary_bulk.md || exit 1;
+$SILK -test.v -silk.url $API silk_vocabulary_anon_cud.md || exit 1;
+$SILK -test.v -silk.url $API silk_vocabulary_anon_r.md || exit 1;
+$SILK -test.v -silk.url $API silk_document_types_crud.md || exit 1;
+$SILK -test.v -silk.url $API silk_document_bulk.md || exit 1;
+$SILK -test.v -silk.url $API silk_geofield.md || exit 1;
+$SILK -test.v -silk.url $API silk_linkfield.md || exit 1;
+$SILK -test.v -silk.url $API silk_child_terms.md || exit 1;
+$SILK -test.v -silk.url $API silk_private.md || exit 1;
+$SILK -test.v -silk.url $API silk_document_revisions.md || exit 1;
+$SILK -test.v -silk.url $API silk_term_revisions.md || exit 1;
 
 # Clear docstore, general tests
 $DRUSH eval "_docstore_setup_testing()"
@@ -53,12 +54,12 @@ export ME_UUID=$(cat me.json | awk -F '"' '{print $4}')
 export ME_SHARED=$(cat me.json | awk -F '"' '{print $16}')
 export HASH=$(php -r "print md5('$ME_SHARED$FILEPRIVATETXT$ME_UUID');")
 
-./silk -test.v -silk.url $HOST silk_files_direct.md || exit 1;
-./silk -test.v -silk.url $API silk_files.md || exit 1;
-./silk -test.v -silk.url $API silk_create.md || exit 1;
-./silk -test.v -silk.url $API silk_exceptions.md || exit 1;
+$SILK -test.v -silk.url $HOST silk_files_direct.md || exit 1;
+$SILK -test.v -silk.url $API silk_files.md || exit 1;
+$SILK -test.v -silk.url $API silk_create.md || exit 1;
+$SILK -test.v -silk.url $API silk_exceptions.md || exit 1;
 
 ## Add countries vocabulary.
 $DRUSH --verbose scr ../html/modules/custom/docstore/syncs/docstore_countries.php
 
-./silk -test.v -silk.url $API silk_document_crud.md || exit 1;
+$SILK -test.v -silk.url $API silk_document_crud.md || exit 1;

--- a/tests/silk_document_crud.md
+++ b/tests/silk_document_crud.md
@@ -1063,7 +1063,7 @@ Delete private document as other provider.
 
 ===
 
-* Status: `400`
+* Status: `403`
 * Content-Type: "application/json"
 
 ## DELETE /documents/test-document-crud/{doc3}

--- a/tests/silk_files.md
+++ b/tests/silk_files.md
@@ -35,7 +35,21 @@ Get private file as anonymous.
 
 ===
 
-* Status: `400`
+* Status: `403`
+* Content-Type: "application/json"
+* Data.message: "Provider is required"
+
+## GET /files/{FILEPRIVATE}
+
+Get private file as a different provider.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: dcba
+
+===
+
+* Status: `403`
 * Content-Type: "application/json"
 * Data.message: "File is not owned by you"
 
@@ -101,9 +115,23 @@ Get private media as anonymous.
 
 ===
 
-* Status: `400`
+* Status: `403`
 * Content-Type: "application/json"
-* Data.message: "Media is not owned by you"
+* Data.message: "Provider is required"
+
+## GET /media/{media_private}
+
+Get private media as a different provider.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: dcba
+
+===
+
+* Status: `403`
+* Content-Type: "application/json"
+* Data.message: "File is not owned by you"
 
 ## GET /media/{media_public}
 
@@ -184,9 +212,22 @@ Get private media content as anonymous.
 
 ===
 
-* Status: `400`
+* Status: `403`
 * Content-Type: "application/json"
-* Data.message: "Media is not owned by you"
+* Data.message: "Provider is required"
+
+## GET /media/{media_private}/content
+
+Get private media content as a different provider.
+
+* Content-Type: "application/json"
+* API-KEY: dcba
+
+===
+
+* Status: `403`
+* Content-Type: "application/json"
+* Data.message: "File is not owned by you"
 
 ## GET /media/{media_public}/content
 
@@ -351,7 +392,7 @@ Make public file private as other provider.
 
 ===
 
-* Status: `400`
+* Status: `403`
 * Content-Type: "application/json"
 
 ## PUT /files/{FILEPUBLIC}
@@ -396,9 +437,24 @@ Get now private file as anonymous.
 
 ===
 
-* Status: `400`
+* Status: `403`
+* Content-Type: "application/json"
+* Data.message: "Provider is required"
+
+## GET /files/{FILEPUBLIC}
+
+Get now private file with a different provider.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: dcba
+
+===
+
+* Status: `403`
 * Content-Type: "application/json"
 * Data.message: "File is not owned by you"
+
 
 ## PUT /files/{FILEPUBLIC}
 

--- a/tests/silk_private.md
+++ b/tests/silk_private.md
@@ -427,7 +427,7 @@ Example output.
 }
 ```
 
-* Status: `400`
+* Status: `403`
 * Content-Type: "application/json"
 * Data.message: "Term is not owned by you"
 

--- a/tests/silk_webhooks.md
+++ b/tests/silk_webhooks.md
@@ -91,7 +91,7 @@ Delete web hooks.
 }
 ```
 
-* Status: `400`
+* Status: `403`
 * Content-Type: "application/json"
 
 ## DELETE /webhooks/{machine_name}


### PR DESCRIPTION
Ticket: DOC-41

## Traits

This moves common code to parse request's content, check provider rights (can create/update/delete, can read, is owner etc.) and handle response (json response, cacheable json response etc.) to traits to consolidate the API's behavior and to help if we want to add some logging for example.

There is a new `ResourceTrait` for the request parsing and response handling. 

Provider checks were moved to the `ProviderTrait` though there is still the `providerCanUseField()` on the MetadataTrait as it's relevant there as well and the `providerCanUseVocabulary()` is also still in the `VocubularyController`. @attiks What do you think?

I also changed the `types` route to use the `{type}` parameter instead of `{node_type}` because it was confusing to have `$node_type` mean either the string type or the entity in the code so now `$type` is always a string and `$node_type` is always the entity.

## Status codes

A few response status codes were changed from 400 Bad Request to 403 Forbidden. This mostly happens when checking the provider as that seemed more semantically correct.

Some responses for when a resource (document, term etc.) is not found where also changed from 400 to 404.

The download endpoints still throw a 400 when the file uuid, media uuid, provider etc. is not correct. I would argue that a 404 should be returned in those cases as in the end the requested file/media URL was not found. What do you think?

## Files endpoint

When requesting a non existing file via a `/files/a/b/c/example.ext`, the API was returning a drupal 404 page (html) because the Exception Event handler didn't handle the exception as the `/files` and `/media` routes don't have the `docstore_crud` options. I added this option to those routes so that we can get a JSON response with the message set by the DownloadController (ex: "Hash does not match"). 

As mentioned above the exceptions are currently all 400 Bad Requests but I think we should change some of those to 404.

## Webhooks

Another change to consolidate behavior with other endpoints is that the response when getting webhooks is now cached (with a context on the `user` so it can vary by provider and the `webhooks` cache tag).

## Tests

I updated the tests to match the status codes change and also allow to specify the `silk` executable path.