### PR TITLE
[DOC-22] Allow create, update and delete operations with bulk endpoints

### DIFF
--- a/html/modules/custom/docstore/docstore.module
+++ b/html/modules/custom/docstore/docstore.module
@@ -85,6 +85,14 @@ function _docstore_setup_testing() {
   $documents = \Drupal::entityTypeManager()->getStorage('node')->loadMultiple();
   \Drupal::entityTypeManager()->getStorage('node')->delete($documents);
 
+  // Delete all node types.
+  $node_types = \Drupal::entityTypeManager()->getStorage('node_type')->loadMultiple();
+  \Drupal::entityTypeManager()->getStorage('node_type')->delete($node_types);
+
+  // Rebuild endpoints.
+  \Drupal::service('docstore.document_controller')
+    ->rebuildEndpoints();
+
   // Delete all terms.
   // @todo skip shared vocabularies.
   $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadMultiple();
@@ -232,6 +240,8 @@ function _docstore_setup_testing() {
   Cache::invalidateTags(['documents']);
   Cache::invalidateTags(['webhooks']);
   Cache::invalidateTags(['document_fields']);
+  Cache::invalidateTags(['terms']);
+  Cache::invalidateTags(['vocabularies']);
 }
 
 /**
@@ -246,6 +256,7 @@ function docstore_create_node_type($type = 'document', $endpoint = 'documents') 
   $manager = new ManageFields($provider, $type, Drupal::service('entity_field.manager'), Drupal::service('database'));
   $manager->createDocumentType([
     'label' => ucfirst($type),
+    'machine_name' => $type,
     'endpoint' => $endpoint,
     'author' => 'common',
     'fields_allowed' => TRUE,

--- a/html/modules/custom/docstore/docstore.routing.yml
+++ b/html/modules/custom/docstore/docstore.routing.yml
@@ -240,8 +240,8 @@ docstore_create_document:
 docstore_create_document_in_bulk:
   path: '/api/v1/documents/{type}/bulk'
   defaults:
-    _controller: 'docstore.document_controller:createDocumentInBulk'
-    _title: 'Create documents in bulk'
+    _controller: 'docstore.document_controller:processDocumentsInBulk'
+    _title: 'Create, udpate or delete documents in bulk'
   methods: [POST]
   requirements:
     _docstore_access_check: 'TRUE'
@@ -398,7 +398,7 @@ docstore_get_vocabulary_terms:
 docstore_create_term_in_vocabulary:
   path: '/api/v1/vocabularies/{id}/terms'
   defaults:
-    _controller: 'docstore.vocabulary_controller:createTermOnVocabulary'
+    _controller: 'docstore.vocabulary_controller:createTerm'
     _title: 'Create term'
   methods: [POST]
   requirements:
@@ -410,8 +410,8 @@ docstore_create_term_in_vocabulary:
 docstore_create_term_in_bulk:
   path: '/api/v1/vocabularies/{id}/terms/bulk'
   defaults:
-    _controller: 'docstore.vocabulary_controller:createTermOnVocabularyInBulk'
-    _title: 'Create term in bulk'
+    _controller: 'docstore.vocabulary_controller:processTermsInBulk'
+    _title: 'Create, udpate or delete terms in bulk'
   methods: [POST]
   requirements:
     _docstore_access_check: 'TRUE'

--- a/html/modules/custom/docstore/src/Controller/DocumentController.php
+++ b/html/modules/custom/docstore/src/Controller/DocumentController.php
@@ -15,6 +15,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystem;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\ProxyClass\File\MimeType\MimeTypeGuesser;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\State\State;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\docstore\DocumentTypeTrait;
@@ -26,9 +27,11 @@ use Drupal\file\Entity\File;
 use Drupal\file\FileUsage\FileUsageInterface;
 use Drupal\media\Entity\Media;
 use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
 use Drupal\user\Entity\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -126,6 +129,33 @@ class DocumentController extends ControllerBase {
   protected $entityUsage;
 
   /**
+   * Proteced node fields.
+   *
+   * @var array
+   */
+  protected static $protectedNodeFields = [
+    'author' => TRUE,
+    'provider_uuid' => TRUE,
+    'changed' => TRUE,
+    'created' => TRUE,
+    'default_langcode' => TRUE,
+    'langcode' => TRUE,
+    'parent' => TRUE,
+    'revision_created' => TRUE,
+    'revision_id' => TRUE,
+    'revision_log_message' => TRUE,
+    'revision_user' => TRUE,
+    'status' => TRUE,
+    'promote' => TRUE,
+    'sticky' => TRUE,
+    'type' => TRUE,
+    'nid' => TRUE,
+    'uuid' => TRUE,
+    'vid' => TRUE,
+    'uid' => TRUE,
+  ];
+
+  /**
    * {@inheritdoc}
    */
   public function __construct(ConfigFactoryInterface $config,
@@ -162,42 +192,49 @@ class DocumentController extends ControllerBase {
     // Check if type is allowed.
     $type = $this->typeAllowed($type, 'write');
 
-    // Get provider.
-    $provider = $this->requireProvider();
-
     // Parse JSON.
     $params = $this->getRequestContent($request);
 
-    // Create document.
-    $document = $this->createDocumentForProvider($type, $params, $provider);
+    /** @var \Drupal\node\Entity\NodeType $node_type */
+    $node_type = $this->loadNodeType($type);
 
-    $data = [
-      'message' => strtr('@type created', ['@type' => $this->getNodeTypeLabel($type)]),
-      'uuid' => $document->uuid(),
-    ];
+    /** @var \Drupal\Core\Session\AccountInterface $provider */
+    $provider = $this->requireProvider();
+
+    // Create document.
+    $data = $this->createDocumentFromParameters($node_type, $params, $provider);
 
     return $this->createJsonResponse($data, 201);
   }
 
   /**
-   * Create document for provider.
+   * Create document from the given parameters.
+   *
+   * @param \Drupal\node\Entity\NodeType $node_type
+   *   Node type entity.
+   * @param array $params
+   *   Parameters to create the document with.
+   * @param \Drupal\Core\Session\AccountInterface $provider
+   *   Provider.
+   *
+   * @return array
+   *   Associative array with the document uuid and a "Doctype created" message.
    */
-  protected function createDocumentForProvider($type, $params, $provider) {
+  protected function createDocumentFromParameters(NodeType $node_type, array $params, AccountInterface $provider) {
     // Check if provider can create documents.
-    $this->providerCanCreateUpdateDelete($this->getNodeType($type));
+    $this->providerCanCreateUpdateDelete($node_type, $provider);
 
     // Check required fields.
     if (empty($params['title'])) {
       throw new BadRequestHttpException('Title is required');
     }
-
     if (empty($params['author'])) {
       throw new BadRequestHttpException('Author is required');
     }
 
     // Create node.
     $item = [
-      'type' => $type,
+      'type' => $node_type->id(),
       'title' => $params['title'],
       'uid' => $provider->id(),
       'author' => [],
@@ -223,7 +260,7 @@ class DocumentController extends ControllerBase {
       ];
     }
 
-    // Store HID Id.
+    // Store author.
     $item['author'][] = [
       'value' => $params['author'],
     ];
@@ -262,28 +299,31 @@ class DocumentController extends ControllerBase {
     // Check for meta tags.
     if (isset($params['metadata']) && $params['metadata']) {
       $metadata = $params['metadata'];
-      $item = array_merge($item, $this->buildItemDataFromMetaData($metadata, $type, $provider, $params['author'], 'node'));
+      $item = array_merge($item, $this->buildItemDataFromMetaData($metadata, $node_type->id(), $provider, $params['author'], 'node'));
     }
 
     /** @var \Drupal\node\Entity\Node $document */
     $document = Node::create($item);
 
-    // Trigger validation.
-    $violations = $document->validate();
-    if (count($violations) > 0) {
-      throw new BadRequestHttpException(strtr('Unable to save document: @error (@path)', [
-        '@error' => strip_tags($violations->get(0)->getMessage()),
-        '@path' => $violations->get(0)->getPropertyPath(),
-      ]));
+    // Check for invalid fields.
+    foreach ($item as $key => $data) {
+      if (!$document->hasField($key)) {
+        throw new BadRequestHttpException(strtr('Unknown field @field', [
+          '@field' => $key,
+        ]));
+      }
     }
 
-    // Save document.
-    $document->save();
+    // Validate and save the document.
+    $this->validateAndSaveEntity($document);
 
     // Invalidate cache.
     Cache::invalidateTags(['documents']);
 
-    return $document;
+    return [
+      'message' => strtr('@type created', ['@type' => $node_type->label()]),
+      'uuid' => $document->uuid(),
+    ];
   }
 
   /**
@@ -313,261 +353,286 @@ class DocumentController extends ControllerBase {
   }
 
   /**
-   * Create document.
+   * Process documents (create, update, delete) in bulk.
+   *
+   * @param string $type
+   *   Document type.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   API request.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   API response.
    */
-  public function createDocumentInBulk($type, Request $request) {
+  public function processDocumentsInBulk($type, Request $request) {
     // Check if type is allowed.
     $type = $this->typeAllowed($type, 'write');
-
-    // Get provider.
-    $provider = $this->requireProvider();
 
     // Parse JSON.
     $params = $this->getRequestContent($request);
 
-    if (empty($params['documents'])) {
-      throw new BadRequestHttpException('documents is required');
+    /** @var \Drupal\node\Entity\NodeType $node_type */
+    $node_type = $this->loadNodeType($type);
+
+    // Get the provider.
+    $provider = $this->requireProvider();
+
+    // Check if the provider can create/update/delete this type of documents.
+    $this->providerCanCreateUpdateDelete($node_type, $provider);
+
+    // @todo move all those checks in a separate class to validate request
+    // content.
+    //
+    // Check that the author property is set.
+    if (empty($params['author']) || !is_string($params['author'])) {
+      throw new BadRequestHttpException('The "author" property is required and must be a string');
+    }
+    $author = $params['author'];
+
+    // Check that the list of terms is present.
+    if (empty($params['documents']) || !is_array($params['documents'])) {
+      throw new BadRequestHttpException('The "documents" property is required and must be an array.');
     }
 
+    // @todo either throw an error if any of the term is not correct (perhaps
+    // do some validation before actually attempting to create the terms or
+    // catch any exception and return that, letting the entire list be processed
+    // or some intermediary.
     $data = [];
     foreach ($params['documents'] as $document) {
-      // Add common fields.
-      $document['author'] = $params['author'];
+      // Default to creation for compatibility.
+      // @todo add breaking change by requiring the "_action" parameter?
+      $action = $document['_action'] ?? 'create';
+      unset($document['_action']);
 
-      // Create document.
-      $doc = $this->createDocumentForProvider($type, $document, $provider);
+      try {
+        switch ($action) {
+          case 'create':
+            // We only add the author when creating terms as it cannot be
+            // changed afterwards.
+            $document['author'] = $author;
+            $data[] = $this->createDocumentFromParameters($node_type, $document, $provider);
+            break;
 
-      $data[] = [
-        'message' => strtr('@type created', ['@type' => $this->getNodeTypeLabel($type)]),
-        'uuid' => $doc->uuid(),
-      ];
+          case 'update':
+            $data[] = $this->updateDocumentFromParameters($node_type, $document, $provider);
+            break;
+
+          case 'delete':
+            $data[] = $this->deleteDocumentFromParameters($node_type, $document, $provider);
+            break;
+
+          default:
+            throw new BadRequestHttpException('Unrecognized action');
+        }
+      }
+      catch (\Exception $exception) {
+        $code = $exception instanceof HttpException ? $exception->getStatusCode() : 500;
+        $data[] = [
+          'error' => [
+            'status' => $code,
+            'message' => $exception->getMessage(),
+          ],
+        ];
+      }
+
     }
 
-    return $this->createJsonResponse($data, 201);
+    return $this->createJsonResponse($data, 200);
   }
 
   /**
    * Update document.
+   *
+   * @param string $type
+   *   Document type.
+   * @param string $id
+   *   Document uuid.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   API request.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   API response.
    */
   public function updateDocument($type, $id, Request $request) {
     // Check if type is allowed.
     $type = $this->typeAllowed($type, 'write');
 
-    $protected_fields = [
-      'author',
-      'provider_uuid',
-      'changed',
-      'created',
-      'default_langcode',
-      'langcode',
-      'parent',
-      'revision_created',
-      'revision_id',
-      'revision_log_message',
-      'revision_user',
-      'status',
-      'promote',
-      'sticky',
-      'type',
-      'nid',
-      'uuid',
-      'vid',
-      'uid',
-    ];
-
-    // Load document.
-    $document = $this->loadDocument($id);
-    if (!$document) {
-      throw new NotFoundHttpException(strtr('Document @uuid does not exist', ['@uuid' => $id]));
-    }
-
     // Parse JSON.
     $params = $this->getRequestContent($request);
 
+    /** @var \Drupal\node\Entity\NodeType $node_type */
+    $node_type = $this->loadNodeType($type);
+
+    /** @var \Drupal\Core\Session\AccountInterface $provider */
+    $provider = $this->requireProvider();
+
+    // Pass the document id to load the document.
+    $params['id'] = $id;
+
+    // Update the document.
+    $data = $this->updateDocumentFromParameters($node_type, $params, $provider, $request->getMethod() === 'PUT');
+
+    return $this->createJsonResponse($data, 200);
+  }
+
+  /**
+   * Update a document from a set of parameters.
+   *
+   * @param \Drupal\node\Entity\NodeType $node_type
+   *   Document type.
+   * @param array $params
+   *   Paramaters to update the document with.
+   * @param \Drupal\Core\Session\AccountInterface $provider
+   *   Provider.
+   * @param bool $full_update
+   *   Whether to perform a full or partial update of the document.
+   *
+   * @return array
+   *   Associative array with the document uuid and a "Doctype updated" message.
+   */
+  public function updateDocumentFromParameters(NodeType $node_type, array $params, AccountInterface $provider, $full_update = TRUE) {
+    // Check if the provider can create/update/delete this type of documents.
+    $this->providerCanCreateUpdateDelete($node_type, $provider);
+
+    // Load document.
+    $document_id = $params['uuid'] ?? $params['id'] ?? '';
+    if (empty($document_id)) {
+      throw new BadRequestHttpException('Document id is required');
+    }
+    $document = $this->loadDocument($document_id);
+    unset($params['uuid']);
+    unset($params['id']);
+
+    // Remove the author as it cannot be changed.
+    unset($params['author']);
+
+    // Make sure the node belongs to the node type.
+    $this->validateEntityBundle($document, $node_type);
+
     // A document can only be updated by its owner.
-    $this->providerIsOwner($document);
+    $this->providerIsOwner($document, $provider);
 
     // Check required fields.
-    if ($request->getMethod() === 'PUT') {
+    if ($full_update) {
       if (empty($params['title'])) {
         throw new BadRequestHttpException('Title is required');
       }
     }
 
     // Re-map fields.
+    // @todo check that it's a boolean.
     if (isset($params['private'])) {
       $document->set('private', $params['private']);
       unset($params['private']);
     }
 
+    // @todo check that it's a boolean.
     if (isset($params['published'])) {
       $document->setPublished($params['published']);
       unset($params['published']);
     }
 
-    $updated_fields = [];
-
-    // Update all fields specified in metadata.
-    if (isset($params['metadata'])) {
-      $metadata = $params['metadata'];
-      if (!is_array($metadata) || $this->arrayIsAssociative($metadata)) {
-        throw new BadRequestHttpException('Metadata has to be an array');
-      }
-
-      foreach ($metadata as $metaitem) {
-        foreach ($metaitem as $name => $values) {
-          // Make sure protected fields aren't set.
-          if (isset($protected_fields[$name])) {
-            throw new BadRequestHttpException(strtr('Field @name cannot be changed', ['@name' => $name]));
-          }
-
-          if ($document->hasField($name)) {
-            $document->set($name, $values);
-            $updated_fields[] = $name;
-          }
-          else {
-            throw new BadRequestHttpException(strtr('Field @name does not exists', ['@name' => $name]));
-          }
-        }
-      }
-      unset($params['metadata']);
-    }
-
-    // Update all fields specified in params.
-    foreach ($params as $name => $values) {
-      // Ignore revision fields.
-      if ($name === 'new_revision' || $name === 'revision_log' || $name === 'draft') {
-        continue;
-      }
-
-      // Make sure protected fields aren't set.
-      if (isset($protected_fields[$name])) {
-        throw new BadRequestHttpException(strtr('Field @name cannot be changed', ['@name' => $name]));
-      }
-
-      if ($document->hasField($name)) {
-        if (is_array($values)) {
-          $massaged = [];
-          foreach ($values as &$value) {
-            if (isset($value['uuid'])) {
-              $massaged[] = $value['uuid'];
-            }
-            else {
-              $massaged[] = $value;
-            }
-          }
-          $document->set($name, $massaged);
-        }
-        else {
-          $document->set($name, $values);
-        }
-
-        $updated_fields[] = $name;
-      }
-      else {
-        throw new BadRequestHttpException(strtr('Field @name does not exists', ['@name' => $name]));
-      }
-    }
+    // Update the document fields from the given parameters.
+    $updated_fields = $this->updateEntityFieldsFromParameters($document, $params, static::$protectedNodeFields);
 
     // Remove all fields not part of params.
-    if ($request->getMethod() === 'PUT') {
-      $document_fields = $document->getFields(FALSE);
-      foreach ($document_fields as $document_field) {
-        // Skip name field.
-        if ($document_field->getName() === 'title') {
-          continue;
-        }
-
-        if (in_array($document_field->getName(), $updated_fields)) {
-          continue;
-        }
-
-        if (in_array($document_field->getName(), $protected_fields)) {
-          continue;
-        }
-
-        if (!$document_field->isEmpty()) {
-          $document->set($document_field->getName(), NULL);
-        }
-      }
+    if ($full_update) {
+      $this->emptyEntityFields($document, ['title' => TRUE] + $updated_fields + static::$protectedNodeFields);
     }
 
-    // Check if we need to create a new revision.
-    $document->setRevisionCreationTime(time());
+    // Create a new revision if necessary.
+    $this->createEntityRevisionFromParameters($document, $params, $provider);
 
-    /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->getNodeType($type);
-
-    // Load provider.
-    $provider = $this->getProvider();
-    if ($node_type->isNewRevision() || $params['new_revision'] ?? FALSE) {
-      $document->revision_log = 'Updated';
-      if (isset($params['revision_log'])) {
-        $document->revision_log = $params['revision_log'];
-        unset($params['revision_log']);
-      }
-      $document->setNewRevision();
-      $document->setRevisionUserId($provider->id());
-
-      // Save new revision as draft?
-      $document->isDefaultRevision(TRUE);
-      if ($params['draft'] ?? FALSE) {
-        $document->isDefaultRevision(FALSE);
-      }
-    }
-
-    // Trigger validation.
-    $violations = $document->validate();
-    if (count($violations) > 0) {
-      throw new BadRequestHttpException(strtr('Unable to save document: @error (@path)', [
-        '@error' => strip_tags($violations->get(0)->getMessage()),
-        '@path' => $violations->get(0)->getPropertyPath(),
-      ]));
-    }
-
-    // Save document.
-    $document->save();
-
-    $data = [
-      'message' => strtr('@type updated', ['@type' => $this->getNodeTypeLabel($type)]),
-      'uuid' => $document->uuid(),
-    ];
+    // Validate and save the document.
+    $this->validateAndSaveEntity($document);
 
     // Invalidate cache.
     Cache::invalidateTags(['documents']);
 
-    // Add cache tags.
-    $cache = [
-      'tags' => $document->getCacheTags(),
+    return [
+      'message' => strtr('@type updated', ['@type' => $node_type->label()]),
+      'uuid' => $document->uuid(),
     ];
-
-    return $this->createCacheableJsonResponse($cache, $data, 200);
   }
 
   /**
    * Delete document.
+   *
+   * @param string $type
+   *   Document type.
+   * @param string $id
+   *   Document uuid.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   API request.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   API response.
    */
   public function deleteDocument($type, $id, Request $request) {
     // Check if type is allowed.
     $type = $this->typeAllowed($type, 'write');
 
+    /** @var \Drupal\node\Entity\NodeType $node_type */
+    $node_type = $this->loadNodeType($type);
+
+    /** @var \Drupal\Core\Session\AccountInterface $provider */
+    $provider = $this->requireProvider();
+
+    // Pass the document id to load the document.
+    $params['id'] = $id;
+
+    // Delete the document.
+    $data = $this->deleteDocumentFromParameters($node_type, $params, $provider);
+
+    return $this->createJsonResponse($data, 200);
+  }
+
+  /**
+   * Delete a node from provided parameters.
+   *
+   * @param \Drupal\node\Entity\NodeType $node_type
+   *   Node type.
+   * @param array $params
+   *   Parameters to delete the term with.
+   * @param \Drupal\Core\Session\AccountInterface $provider
+   *   Provider.
+   *
+   * @return array
+   *   Associative array with the node uuid and a "Doctype deleted" message.
+   */
+  public function deleteDocumentFromParameters(NodeType $node_type, array $params, AccountInterface $provider) {
+    // Check if provider can create documents.
+    $this->providerCanCreateUpdateDelete($node_type, $provider);
+
     // Load document.
-    $document = $this->loadDocument($id);
+    $document_id = $params['uuid'] ?? $params['id'] ?? '';
+    if (empty($document_id)) {
+      throw new BadRequestHttpException('Document id is required');
+    }
+    $document = $this->loadDocument($document_id);
+
+    // Make sure the node belongs to the node type.
+    $this->validateEntityBundle($document, $node_type);
 
     // A document can only be deleted by its owner.
-    $this->providerIsOwner($document);
+    $this->providerIsOwner($document, $provider);
 
-    $data = [
-      'message' => strtr('@type deleted', ['@type' => $this->getNodeTypeLabel($type)]),
-      'uuid' => $document->uuid(),
-    ];
+    // Check if document is in use.
+    // @todo discuss if this should be removed.
+    if ($this->entityInUse($document)) {
+      throw new BadRequestHttpException('Document is referenced elsewhere and can not be deleted');
+    }
 
+    // Delete the document.
     $document->delete();
 
     // Invalidate cache.
     Cache::invalidateTags(['documents']);
 
-    return $this->createJsonResponse($data, 200);
+    return [
+      'message' => strtr('@type deleted', ['@type' => $node_type->label()]),
+      'uuid' => $document->uuid(),
+    ];
   }
 
   /**
@@ -580,7 +645,10 @@ class DocumentController extends ControllerBase {
     // Parse JSON.
     $params = $this->getRequestContent($request);
 
-    // Get provider.
+    /** @var \Drupal\node\Entity\NodeType $node_type */
+    $node_type = $this->loadNodeType($type);
+
+    /** @var \Drupal\Core\Session\AccountInterface $provider */
     $provider = $this->requireProvider();
 
     // Check for last.
@@ -599,33 +667,22 @@ class DocumentController extends ControllerBase {
 
     /** @var \Drupal\node\Entity\Node $document */
     $document = $this->entityTypeManager->getStorage('node')->loadRevision($vid);
-
-    // A document can only be updated by its owner.
-    $this->providerIsOwner($document);
-
-    if ($document->uuid() !== $id) {
+    if (!$document || $document->uuid() !== $id) {
       throw new NotFoundHttpException('Revision not found');
     }
 
-    if ($document->bundle() !== $type) {
-      throw new BadRequestHttpException('Wrong document type');
-    }
+    // Make sure the node belongs to the node type.
+    $this->validateEntityBundle($document, $node_type);
 
-    if (!$document->isDefaultRevision()) {
-      $document->setRevisionCreationTime(time());
-      $document->revision_log = 'Updated';
-      if (isset($params['revision_log'])) {
-        $document->revision_log = $params['revision_log'];
-      }
-      $document->setNewRevision();
-      $document->setRevisionUserId($provider->id());
+    // A document can only be updated by its owner.
+    $this->providerIsOwner($document, $provider);
 
-      $document->isDefaultRevision(TRUE);
-      $document->save();
-    }
+    // Publish the revision.
+    $this->publishEntityRevisionFromParameters($document, $params, $provider);
 
     $data = [
-      'message' => strtr('@type updated', ['@type' => $this->getNodeTypeLabel($type)]),
+      // @todo change message.
+      'message' => strtr('@type updated', ['@type' => $node_type->label()]),
       'uuid' => $document->uuid(),
     ];
 
@@ -1118,31 +1175,6 @@ class DocumentController extends ControllerBase {
   }
 
   /**
-   * Load a vocabulary.
-   *
-   * @param string $id
-   *   The vocabulary uuid or entity_id.
-   *
-   * @return \Drupal\taxonomy\Entity\Vocabulary
-   *   Vocabulary.
-   */
-  protected function loadVocabulary($id) {
-    if (Uuid::isValid($id)) {
-      $vocabulary = $this->entityRepository->loadEntityByUuid('taxonomy_vocabulary', $id);
-    }
-    else {
-      // Assume it's the machine name.
-      $vocabulary = $this->entityTypeManager->getStorage('taxonomy_vocabulary')->load($id);
-    }
-
-    if (!$vocabulary) {
-      throw new NotFoundHttpException('Vocabulary does not exist');
-    }
-
-    return $vocabulary;
-  }
-
-  /**
    * Load a document.
    *
    * @param string $id
@@ -1270,26 +1302,6 @@ class DocumentController extends ControllerBase {
     }
 
     return $media_entity;
-  }
-
-  /**
-   * Check if in entity is in use.
-   *
-   * \Drupal\Core\Entity\EntityInterface $entity
-   *   The entity to check.
-   *
-   * @return bool
-   *   TRUE if entity is used somewhere.
-   */
-  protected function entityInUse($entity) {
-    return !empty($this->entityUsage->listSources($entity));
-  }
-
-  /**
-   * Check if an array is associative.
-   */
-  protected function arrayIsAssociative(array $array) {
-    return count(array_filter(array_keys($array), 'is_string')) > 0;
   }
 
   /**

--- a/html/modules/custom/docstore/src/Controller/DocumentReadController.php
+++ b/html/modules/custom/docstore/src/Controller/DocumentReadController.php
@@ -100,7 +100,7 @@ class DocumentReadController extends ControllerBase {
 
     // Check if provider has access.
     if ($type !== 'any') {
-      $this->providerCanRead($this->getNodeType($type));
+      $this->providerCanRead($this->loadNodeType($type));
     }
 
     // Query index.
@@ -387,7 +387,7 @@ class DocumentReadController extends ControllerBase {
 
     // Check if provider has access.
     if ($type !== 'any') {
-      $this->providerCanRead($this->getNodeType($type));
+      $this->providerCanRead($this->loadNodeType($type));
     }
 
     // Query index.

--- a/html/modules/custom/docstore/src/Controller/DocumentTypeController.php
+++ b/html/modules/custom/docstore/src/Controller/DocumentTypeController.php
@@ -111,7 +111,7 @@ class DocumentTypeController extends ControllerBase {
    */
   public function getDocumentType($type, Request $request) {
     /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->getNodeType($type);
+    $node_type = $this->loadNodeType($type);
 
     $data = $this->buildJsonOutput($node_type);
 
@@ -123,7 +123,7 @@ class DocumentTypeController extends ControllerBase {
    */
   public function updateDocumentType($type, Request $request) {
     /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->getNodeType($type);
+    $node_type = $this->loadNodeType($type);
 
     // Get provider.
     $provider = $this->requireProvider();
@@ -145,7 +145,7 @@ class DocumentTypeController extends ControllerBase {
    */
   public function deleteDocumentType($type, Request $request) {
     /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->getNodeType($type);
+    $node_type = $this->loadNodeType($type);
 
     $data = [
       'message' => strtr('@type deleted', ['@type' => $node_type->label()]),
@@ -167,7 +167,7 @@ class DocumentTypeController extends ControllerBase {
    */
   public function getDocumentFields($type) {
     /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->getNodeType($type);
+    $node_type = $this->loadNodeType($type);
 
     // Load provider.
     $provider = $this->requireProvider();
@@ -191,7 +191,7 @@ class DocumentTypeController extends ControllerBase {
    */
   public function createDocumentField($type, Request $request) {
     /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->getNodeType($type);
+    $node_type = $this->loadNodeType($type);
 
     // Parse JSON.
     $params = $this->getRequestContent($request);
@@ -224,7 +224,7 @@ class DocumentTypeController extends ControllerBase {
    */
   public function getDocumentField($type, $id, Request $request) {
     /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->getNodeType($type);
+    $node_type = $this->loadNodeType($type);
 
     // Get provider.
     $provider = $this->requireProvider();
@@ -254,7 +254,7 @@ class DocumentTypeController extends ControllerBase {
    */
   public function updateDocumentField($type, $field, $id, Request $request) {
     /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->getNodeType($type);
+    $node_type = $this->loadNodeType($type);
 
     // Parse JSON.
     $params = $this->getRequestContent($request);
@@ -289,7 +289,7 @@ class DocumentTypeController extends ControllerBase {
    */
   public function deleteDocumentField($type, $id, Request $request) {
     /** @var \Drupal\node\Entity\NodeType $node_type */
-    $node_type = $this->getNodeType($type);
+    $node_type = $this->loadNodeType($type);
 
     // Get provider.
     $provider = $this->requireProvider();

--- a/html/modules/custom/docstore/src/Controller/WebhookController.php
+++ b/html/modules/custom/docstore/src/Controller/WebhookController.php
@@ -159,8 +159,11 @@ class WebhookController extends ControllerBase {
     // Check for duplicate.
     $webhook_config = WebhookConfig::load($id);
 
+    // Get provider.
+    $provider = $this->requireProvider();
+
     // A webhook can only be deleted by its owner.
-    $this->providerIsOwner($webhook_config, 'base_provider_uuid');
+    $this->providerIsOwner($webhook_config, $provider, 'base_provider_uuid');
 
     $webhook_config->delete();
 

--- a/html/modules/custom/docstore/src/ManageFields.php
+++ b/html/modules/custom/docstore/src/ManageFields.php
@@ -960,7 +960,7 @@ class ManageFields {
         $updated_fields[] = $name;
       }
       else {
-        throw new \Exception(strtr('Field @name does not exists', ['@name' => $name]));
+        throw new \Exception(strtr('Field @name does not exist', ['@name' => $name]));
       }
     }
 

--- a/html/modules/custom/docstore/src/MetadataTrait.php
+++ b/html/modules/custom/docstore/src/MetadataTrait.php
@@ -476,7 +476,7 @@ trait MetadataTrait {
     $violations = $entity->validate();
     if (count($violations) > 0) {
       // We only show the first violation.
-      throw new BadRequestHttpException(strtr('Unable to save document: @error (@path)', [
+      throw new BadRequestHttpException(strtr('Unable to save resource: @error (@path)', [
         '@error' => strip_tags($violations->get(0)->getMessage()),
         '@path' => $violations->get(0)->getPropertyPath(),
       ]));

--- a/html/modules/custom/docstore/src/ProviderTrait.php
+++ b/html/modules/custom/docstore/src/ProviderTrait.php
@@ -4,6 +4,7 @@ namespace Drupal\docstore;
 
 // @todo consider creating a docstore `Resource`?
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
@@ -49,6 +50,8 @@ trait ProviderTrait {
    *
    * @param \Drupal\Core\Entity\EntityInterface $resource
    *   Docstore resource (node type or vocabulary).
+   * @param \Drupal\Core\Session\AccountInterface|null $provider
+   *   Provider.
    *
    * @return bool
    *   TRUE if the provider is allowed to create content for the resource.
@@ -57,14 +60,14 @@ trait ProviderTrait {
    *   403 Access Denied if no valid provider is found or if the provider
    *   doesn't have read access to the resource.
    */
-  protected function providerCanRead(EntityInterface $resource) {
+  protected function providerCanRead(EntityInterface $resource, ?AccountInterface $provider = NULL) {
     // Shared resources are always readable.
     if ($resource->getThirdPartySetting('docstore', 'shared')) {
       return TRUE;
     }
 
     // Otherwise a provider is required.
-    $provider = $this->requireProvider();
+    $provider = $provider ?: $this->requireProvider();
 
     // Check if the current provider is the provider of the resource.
     if ($type->getThirdPartySetting('docstore', 'provider_uuid') === $provider->uuid()) {
@@ -81,6 +84,8 @@ trait ProviderTrait {
    *
    * @param \Drupal\Core\Entity\EntityInterface $resource
    *   Docstore resource (node type or vocabulary).
+   * @param \Drupal\Core\Session\AccountInterface|null $provider
+   *   Provider.
    *
    * @return bool
    *   TRUE if the provider is allowed to create content for the resource.
@@ -89,9 +94,9 @@ trait ProviderTrait {
    *   403 Access Denied if no valid provider is found or if the provider
    *   doesn't have create/update/delete access to the resource.
    */
-  protected function providerCanCreateUpdateDelete(EntityInterface $resource) {
+  protected function providerCanCreateUpdateDelete(EntityInterface $resource, ?AccountInterface $provider = NULL) {
     // A provider is required to create, update or delete a resource.
-    $provider = $this->requireProvider();
+    $provider = $provider ?: $this->requireProvider();
 
     // Check if the current provider is the provider of the resource.
     if ($resource->getThirdPartySetting('docstore', 'provider_uuid') == $provider->uuid()) {
@@ -114,6 +119,8 @@ trait ProviderTrait {
    *
    * @param \Drupal\Core\Entity\EntityInterface $resource
    *   Docstore resource (node, term, file etc.).
+   * @param \Drupal\Core\Session\AccountInterface|null $provider
+   *   Provider.
    * @param string $check_type
    *   Type of check to perform:
    *   - owner_id: check the owner id against the current provider's id.
@@ -125,8 +132,8 @@ trait ProviderTrait {
    * @return bool
    *   TRUE if the provider is the owner of the resource.
    */
-  protected function providerIsOwner(EntityInterface $resource, $check_type = 'owner_id') {
-    $provider = $this->requireProvider();
+  protected function providerIsOwner(EntityInterface $resource, ?AccountInterface $provider = NULL, $check_type = 'owner_id') {
+    $provider = $provider ?: $this->requireProvider();
 
     switch ($resource->getEntityTypeId()) {
       case 'node':

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -14,10 +14,12 @@ $DRUSH eval "docstore_create_node_type('document', 'documents')"
 $SILK -test.v -silk.url $API silk_webhooks.md || exit 1;
 $SILK -test.v -silk.url $API silk_vocabulary_crud.md || exit 1;
 $SILK -test.v -silk.url $API silk_vocabulary_bulk.md || exit 1;
+$SILK -test.v -silk.url $API silk_vocabulary_bulk_cud.md || exit 1;
 $SILK -test.v -silk.url $API silk_vocabulary_anon_cud.md || exit 1;
 $SILK -test.v -silk.url $API silk_vocabulary_anon_r.md || exit 1;
 $SILK -test.v -silk.url $API silk_document_types_crud.md || exit 1;
 $SILK -test.v -silk.url $API silk_document_bulk.md || exit 1;
+$SILK -test.v -silk.url $API silk_document_bulk_cud.md || exit 1;
 $SILK -test.v -silk.url $API silk_geofield.md || exit 1;
 $SILK -test.v -silk.url $API silk_linkfield.md || exit 1;
 $SILK -test.v -silk.url $API silk_child_terms.md || exit 1;
@@ -28,6 +30,9 @@ $SILK -test.v -silk.url $API silk_term_revisions.md || exit 1;
 # Clear docstore, general tests
 $DRUSH eval "_docstore_setup_testing()"
 $DRUSH cr
+
+# Add document type
+$DRUSH eval "docstore_create_node_type('document', 'documents')"
 
 # Add files
 (echo -n '{"private":true,"filename":"private.pdf","mime":"application/pdf","data": "'; base64 ./files/private.pdf; echo '"}') | curl -X POST -H  "accept: application/json" -H  "API-KEY: abcd" -H "Content-Type: application/json" -d @-  $API/files > newfile_private.json

--- a/tests/silk_document_bulk.md
+++ b/tests/silk_document_bulk.md
@@ -145,7 +145,7 @@ Add 2 documents.
 
 ===
 
-* Status: `201`
+* Status: `200`
 * Content-Type: "application/json"
 * Data[0].message: "Test document bulk created"
 * Data[0].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {doc2}

--- a/tests/silk_document_bulk_cud.md
+++ b/tests/silk_document_bulk_cud.md
@@ -107,24 +107,7 @@ Create documents in bulk.
 
 ===
 
-Example output.
-
-```json
-[
-  {
-    "message": "Test document bulk CUD created"
-  },
-  {
-    "message": "Test document bulk CUD created"
-  },
-  {
-    "message": "Test document bulk CUD created"
-  },
-  {
-    "message": "Test document bulk CUD created"
-  }
-]
-```
+Expected output.
 
 * Status: `200`
 * Content-Type: "application/json"
@@ -189,30 +172,15 @@ and attempt to update a non existing document in same request.
 
 ===
 
-Example output.
-
-```json
-[
-  {
-    "message": "Test document bulk CUD updated",
-    "uuid": "{doc_uuid1}"
-  },
-  {
-    "message": "Test document bulk CUD deleted",
-    "uuid": "{doc_uuid4}"
-  },
-  {
-    "message": "Test document bulk CUD created"
-  },
-  {
-    "error": {
-      "status": 404,
-      "message": "Document does not exist"
-    }
-  }
-]
-```
+Expected output.
 
 * Status: `200`
 * Content-Type: "application/json"
+* Data[0].message: "Test document bulk CUD updated"
+* Data[0].uuid: {doc_uuid1}
+* Data[1].message: "Test document bulk CUD deleted"
+* Data[1].uuid: {doc_uuid4}
+* Data[2].message: "Test document bulk CUD created"
 * Data[2].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc5 uuid {doc_uuid5}
+* Data[3].error.status: 404
+* Data[3].error.message: "Document does not exist"

--- a/tests/silk_document_bulk_cud.md
+++ b/tests/silk_document_bulk_cud.md
@@ -1,0 +1,218 @@
+# Create, update, delete documents in bulk
+
+## POST /types
+
+Create a document type.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "machine_name": "test_doc_bulk_cud",
+  "endpoint": "test-document-bulk-cud",
+  "label": "Test document bulk CUD",
+  "author": "common"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+
+## POST /types/test_doc_bulk_cud/fields
+
+Add id field.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "My Id",
+  "author": "test",
+  "type": "string"
+}
+```
+
+===
+
+Example output.
+
+```json
+{
+  "message": "Field created"
+}
+```
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Field created"
+* Data.field_name: /^[0-9a-z_]+$/ // Machine_name {field_id}
+
+## POST /documents/test-document-bulk-cud/bulk
+
+Create documents in bulk.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "author": "Author",
+  "documents": [
+    {
+      "_action": "create",
+      "title": "Doc1",
+      "metadata": [
+        {
+          "{field_id}": "doc1"
+        }
+      ]
+    },
+    {
+      "_action": "create",
+      "title": "Doc2",
+      "metadata": [
+        {
+          "{field_id}": "doc2"
+        }
+      ]
+    },
+    {
+      "_action": "create",
+      "title": "Doc3",
+      "metadata": [
+        {
+          "{field_id}": "doc3"
+        }
+      ]
+    },
+    {
+      "_action": "create",
+      "title": "Doc4",
+      "metadata": [
+        {
+          "{field_id}": "doc4"
+        }
+      ]
+    }
+  ]
+}
+```
+
+===
+
+Example output.
+
+```json
+[
+  {
+    "message": "Test document bulk CUD created"
+  },
+  {
+    "message": "Test document bulk CUD created"
+  },
+  {
+    "message": "Test document bulk CUD created"
+  },
+  {
+    "message": "Test document bulk CUD created"
+  }
+]
+```
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data[0].message: "Test document bulk CUD created"
+* Data[1].message: "Test document bulk CUD created"
+* Data[2].message: "Test document bulk CUD created"
+* Data[3].message: "Test document bulk CUD created"
+* Data[0].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc1 uuid {doc_uuid1}
+* Data[1].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc2 uuid {doc_uuid2}
+* Data[2].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc3 uuid {doc_uuid3}
+* Data[3].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc4 uuid {doc_uuid4}
+
+## POST /documents/test-document-bulk-cud/bulk
+
+Update an existing document, delete an existing document, create new document
+and attempt to update a non existing document in same request.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "author": "Author",
+  "documents": [
+    {
+      "_action": "update",
+      "uuid": "{doc_uuid1}",
+      "title": "Doc1 with new label",
+      "metadata": [
+        {
+          "{field_id}": "doc1_new"
+        }
+      ]
+    },
+    {
+      "_action": "delete",
+      "uuid": "{doc_uuid4}"
+    },
+    {
+      "_action": "create",
+      "title": "Doc5",
+      "metadata": [
+        {
+          "{field_id}": "doc5"
+        }
+      ]
+    },
+    {
+      "_action": "update",
+      "uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "title": "Non existing document",
+      "metadata": [
+        {
+          "{field_id}": "nothing"
+        }
+      ]
+    }
+  ]
+}
+```
+
+===
+
+Example output.
+
+```json
+[
+  {
+    "message": "Test document bulk CUD updated",
+    "uuid": "{doc_uuid1}"
+  },
+  {
+    "message": "Test document bulk CUD deleted",
+    "uuid": "{doc_uuid4}"
+  },
+  {
+    "message": "Test document bulk CUD created"
+  },
+  {
+    "error": {
+      "status": 404,
+      "message": "Document does not exist"
+    }
+  }
+]
+```
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data[2].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc5 uuid {doc_uuid5}

--- a/tests/silk_document_crud.md
+++ b/tests/silk_document_crud.md
@@ -1182,13 +1182,13 @@ Example output.
 
 ```json
 {
-  "message": "Unable to save document: This value should not be null. (silk_needed)"
+  "message": "Unable to save resource: This value should not be null. (silk_needed)"
 }
 ```
 
 * Status: `400`
 * Content-Type: "application/json"
-* Data.message: "Unable to save document: This value should not be null. (silk_needed)"
+* Data.message: "Unable to save resource: This value should not be null. (silk_needed)"
 
 ## POST /documents/test-document-crud
 
@@ -1250,9 +1250,9 @@ Example output.
 
 ```json
 {
-  "message": "Unable to save document: This value should be of the correct primitive type. (silk_needed.0.value)"
+  "message": "Unable to save resource: This value should be of the correct primitive type. (silk_needed.0.value)"
 }
 ```
 
 * Content-Type: "application/json"
-* Data.message: "Unable to save document: This value should be of the correct primitive type. (silk_needed.0.value)"
+* Data.message: "Unable to save resource: This value should be of the correct primitive type. (silk_needed.0.value)"

--- a/tests/silk_document_revisions.md
+++ b/tests/silk_document_revisions.md
@@ -226,6 +226,7 @@ Disable revisions.
 
 * Status: `200`
 * Content-Type: "application/json"
+* Data.use_revisions: false
 
 ## PUT /documents/test-revisions/{doc1}
 

--- a/tests/silk_vocabulary_bulk.md
+++ b/tests/silk_vocabulary_bulk.md
@@ -165,7 +165,7 @@ Create city terms.
 
 ===
 
-* Status: `201`
+* Status: `200`
 * Content-Type: "application/json"
 * Data[0].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {term_uuid2}
 * Data[1].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {term_uuid3}

--- a/tests/silk_vocabulary_bulk_cud.md
+++ b/tests/silk_vocabulary_bulk_cud.md
@@ -119,24 +119,7 @@ Create terms in bulk.
 
 ===
 
-Example output.
-
-```json
-[
-  {
-    "message": "Term created"
-  },
-  {
-    "message": "Term created"
-  },
-  {
-    "message": "Term created"
-  },
-  {
-    "message": "Term created"
-  }
-]
-```
+Expected output.
 
 * Status: `200`
 * Content-Type: "application/json"
@@ -260,30 +243,15 @@ update a non existing term in the same request.
 
 ===
 
-Example output.
-
-```json
-[
-  {
-    "message": "Term updated",
-    "uuid": "{term_uuid1}"
-  },
-  {
-    "message": "Term deleted",
-    "uuid": "{term_uuid4}"
-  },
-  {
-    "message": "Term created"
-  },
-  {
-    "error": {
-      "status": 404,
-      "message": "Term does not exist"
-    }
-  }
-]
-```
+Expected output.
 
 * Status: `200`
 * Content-Type: "application/json"
-* Data[2].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Term5 uuid {term_uuid5}
+* Data[0].message: "Term updated"
+* Data[0].uuid: {term_uuid1}
+* Data[1].message: "Term deleted"
+* Data[1].uuid: {term_uuid4}
+* Data[2].message: "Term created"
+* Data[2].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc5 uuid {term_uuid5}
+* Data[3].error.status: 404
+* Data[3].error.message: "Term does not exist"

--- a/tests/silk_vocabulary_bulk_cud.md
+++ b/tests/silk_vocabulary_bulk_cud.md
@@ -1,0 +1,289 @@
+# Create, update, delete terms in bulk
+
+## POST /vocabularies
+
+Create vocabulary.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Bulk CUD terms",
+  "machine_name": "voc_bulk_cud",
+  "author": "test",
+  "allow_duplicates": false
+}
+```
+
+===
+
+Example output.
+
+```json
+{
+  "message": "Vocabulary created"
+}
+```
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Vocabulary created"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // UUID {uuid}
+* Data.machine_name: /^[0-9a-z_]+$/ // Machine_name {machine_name}
+
+## POST /vocabularies/{machine_name}/fields
+
+Add iso3 field to vocabulary.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "ISO 3 code",
+  "author": "test",
+  "type": "string"
+}
+```
+
+===
+
+Example output.
+
+```json
+{
+  "message": "Field created"
+}
+```
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Field created"
+* Data.field_name: /^[0-9a-z_]+$/ // Machine_name {field_iso3}
+
+
+## POST /vocabularies/{machine_name}/terms/bulk
+
+Create terms in bulk.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "author": "Author",
+  "terms": [
+    {
+      "_action": "create",
+      "label": "Term1",
+      "metadata": [
+        {
+          "{field_iso3}": "AFG"
+        }
+      ]
+    },
+    {
+      "_action": "create",
+      "label": "Term2",
+      "metadata": [
+        {
+          "{field_iso3}": "BEL"
+        }
+      ]
+    },
+    {
+      "_action": "create",
+      "label": "Term3",
+      "metadata": [
+        {
+          "{field_iso3}": "FRA"
+        }
+      ]
+    },
+    {
+      "_action": "create",
+      "label": "Term4",
+      "metadata": [
+        {
+          "{field_iso3}": "OPT"
+        }
+      ]
+    }
+  ]
+}
+```
+
+===
+
+Example output.
+
+```json
+[
+  {
+    "message": "Term created"
+  },
+  {
+    "message": "Term created"
+  },
+  {
+    "message": "Term created"
+  },
+  {
+    "message": "Term created"
+  }
+]
+```
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data[0].message: "Term created"
+* Data[1].message: "Term created"
+* Data[2].message: "Term created"
+* Data[3].message: "Term created"
+* Data[0].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Term1 uuid {term_uuid1}
+* Data[1].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Term2 uuid {term_uuid2}
+* Data[2].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Term3 uuid {term_uuid3}
+* Data[3].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Term4 uuid {term_uuid4}
+
+## POST /vocabularies/{machine_name}/terms/bulk
+
+Try to create new terms with the same label.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "author": "Author",
+  "terms": [
+    {
+      "_action": "create",
+      "label": "Term1",
+      "metadata": [
+        {
+          "{field_iso3}": "AFG"
+        }
+      ]
+    },
+    {
+      "_action": "create",
+      "label": "Term2",
+      "metadata": [
+        {
+          "{field_iso3}": "BEL"
+        }
+      ]
+    }
+  ]
+}
+```
+
+===
+
+Example output.
+
+```json
+[
+  {
+    "error": {
+      "status": 400,
+      "message": "Term with same label already exists"
+    }
+  },
+  {
+    "error": {
+      "status": 400,
+      "message": "Term with same label already exists"
+    }
+  }
+]
+```
+
+* Status: `200`
+* Content-Type: "application/json"
+
+
+## POST /vocabularies/{machine_name}/terms/bulk
+
+Update an existing term, delete an existing term, create new term and attempt to
+update a non existing term in the same request.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "author": "Author",
+  "terms": [
+    {
+      "_action": "update",
+      "uuid": "{term_uuid1}",
+      "label": "Term1 with new label",
+      "metadata": [
+        {
+          "{field_iso3}": "AFG"
+        }
+      ]
+    },
+    {
+      "_action": "delete",
+      "uuid": "{term_uuid4}"
+    },
+    {
+      "_action": "create",
+      "label": "Term5",
+      "metadata": [
+        {
+          "{field_iso3}": "AFG"
+        }
+      ]
+    },
+    {
+      "_action": "update",
+      "uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "label": "Non existing term",
+      "metadata": [
+        {
+          "{field_iso3}": "AFG"
+        }
+      ]
+    }
+  ]
+}
+```
+
+===
+
+Example output.
+
+```json
+[
+  {
+    "message": "Term updated",
+    "uuid": "{term_uuid1}"
+  },
+  {
+    "message": "Term deleted",
+    "uuid": "{term_uuid4}"
+  },
+  {
+    "message": "Term created"
+  },
+  {
+    "error": {
+      "status": 404,
+      "message": "Term does not exist"
+    }
+  }
+]
+```
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data[2].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Term5 uuid {term_uuid5}

--- a/tests/silk_vocabulary_crud.md
+++ b/tests/silk_vocabulary_crud.md
@@ -242,13 +242,13 @@ Example output.
 
 ```json
 {
-  "message": "Field author does not exists"
+  "message": "Field author does not exist"
 }
 ```
 
 * Status: `400`
 * Content-Type: "application/json"
-* Data.message: "Field author does not exists"
+* Data.message: "Field author does not exist"
 
 ## PUT /vocabularies/{machine_name}
 


### PR DESCRIPTION
Ticket: DOC-22

The primary goal of this PR is to allow create, update and delete operations when querying the documents or terms bulk endpoints by specifying for each items in the list the type of action via a `_action` property.

When the `_action` is not provided, it's considered a `create` operation for compatibility with the existing behavior of the `bulk` endpoints. Maybe we can remove this and always require the `_action` to be defined.

Currently the 3 actions are:

- `create`
- `update` (full update equivalent to a PUT)
- `delete`

Maybe we could allow partial updates via a `partial_update` action. That would be easy to add code-wise. Thoughts?

The returned data is a list of json objects with the `entity uuid` and `message` (ex: Term created) when the operation for the corresponding item in the request was successful or with a `error` that contains a `status` and the error message.

That should allow the client to validate the results of the API request.

## Code cleanup

In order to perform those CUD operations, a lot of code had to be moved around. I took the opportunity to consolidate the method signatures and logic between the VocabularyController and DocumentController, moving some common code to the `MetadataTrait` (mostly). 

Some entity related methods could be moved to another trait like the ResourceTrait but they are probably fine where they are for now.

## Tests

There are 2 new tests files for the bulk CUD operations and all the tests pass.

I added some resets of the node types and documents endpoints in the `_docstore_setup_testing()` function so there is no leftovers when running again the tests.


