### PR TITLE
[DOC-22] Use http methods rather than _action property for bulk endpoints

### DIFF
--- a/html/modules/custom/docstore/docstore.routing.yml
+++ b/html/modules/custom/docstore/docstore.routing.yml
@@ -241,8 +241,8 @@ docstore_create_document_in_bulk:
   path: '/api/v1/documents/{type}/bulk'
   defaults:
     _controller: 'docstore.document_controller:processDocumentsInBulk'
-    _title: 'Create, udpate or delete documents in bulk'
-  methods: [POST]
+    _title: 'Create, update or delete documents in bulk'
+  methods: [POST, 'PUT', 'PATCH', 'DELETE']
   requirements:
     _docstore_access_check: 'TRUE'
   options:
@@ -411,8 +411,8 @@ docstore_create_term_in_bulk:
   path: '/api/v1/vocabularies/{id}/terms/bulk'
   defaults:
     _controller: 'docstore.vocabulary_controller:processTermsInBulk'
-    _title: 'Create, udpate or delete terms in bulk'
-  methods: [POST]
+    _title: 'Create, update or delete terms in bulk'
+  methods: [POST, 'PUT', 'PATCH', 'DELETE']
   requirements:
     _docstore_access_check: 'TRUE'
   options:

--- a/html/modules/custom/docstore/src/Controller/VocabularyController.php
+++ b/html/modules/custom/docstore/src/Controller/VocabularyController.php
@@ -525,31 +525,31 @@ class VocabularyController extends ControllerBase {
     }
 
     $data = [];
+    $method = $request->getMethod();
     foreach ($params['terms'] as $term) {
-      // Default to creation for compatibility.
-      // @todo add breaking change by requiring the "_action" parameter?
-      $action = $term['_action'] ?? 'create';
-      unset($term['_action']);
-
       try {
-        switch ($action) {
-          case 'create':
+        switch ($method) {
+          case 'POST':
             // We only add the author when creating terms as it cannot be
             // changed afterwards.
             $term['author'] = $author;
             $data[] = $this->createTermFromParameters($vocabulary, $term, $provider);
             break;
 
-          case 'update':
-            $data[] = $this->updateTermFromParameters($vocabulary, $term, $provider);
+          case 'PUT':
+            $data[] = $this->updateTermFromParameters($vocabulary, $term, $provider, TRUE);
             break;
 
-          case 'delete':
+          case 'PATCH':
+            $data[] = $this->updateTermFromParameters($vocabulary, $term, $provider, FALSE);
+            break;
+
+          case 'DELETE':
             $data[] = $this->deleteTermFromParameters($vocabulary, $term, $provider);
             break;
 
           default:
-            throw new BadRequestHttpException('Unrecognized action');
+            throw new BadRequestHttpException('Unrecognized bulk operation');
         }
       }
       catch (\Exception $exception) {

--- a/tests/silk_document_bulk_cud.md
+++ b/tests/silk_document_bulk_cud.md
@@ -66,7 +66,6 @@ Create documents in bulk.
   "author": "Author",
   "documents": [
     {
-      "_action": "create",
       "title": "Doc1",
       "metadata": [
         {
@@ -75,7 +74,6 @@ Create documents in bulk.
       ]
     },
     {
-      "_action": "create",
       "title": "Doc2",
       "metadata": [
         {
@@ -84,7 +82,6 @@ Create documents in bulk.
       ]
     },
     {
-      "_action": "create",
       "title": "Doc3",
       "metadata": [
         {
@@ -93,7 +90,6 @@ Create documents in bulk.
       ]
     },
     {
-      "_action": "create",
       "title": "Doc4",
       "metadata": [
         {
@@ -120,10 +116,9 @@ Expected output.
 * Data[2].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc3 uuid {doc_uuid3}
 * Data[3].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc4 uuid {doc_uuid4}
 
-## POST /documents/test-document-bulk-cud/bulk
+## PUT /documents/test-document-bulk-cud/bulk
 
-Update an existing document, delete an existing document, create new document
-and attempt to update a non existing document in same request.
+Update documents in bulk. This is a full update so the `title` is mandatory.
 
 * Content-Type: "application/json"
 * Accept: "application/json"
@@ -134,7 +129,6 @@ and attempt to update a non existing document in same request.
   "author": "Author",
   "documents": [
     {
-      "_action": "update",
       "uuid": "{doc_uuid1}",
       "title": "Doc1 with new label",
       "metadata": [
@@ -144,20 +138,14 @@ and attempt to update a non existing document in same request.
       ]
     },
     {
-      "_action": "delete",
-      "uuid": "{doc_uuid4}"
-    },
-    {
-      "_action": "create",
-      "title": "Doc5",
+      "uuid": "{doc_uuid2}",
       "metadata": [
         {
-          "{field_id}": "doc5"
+          "{field_id}": "doc2_new"
         }
       ]
     },
     {
-      "_action": "update",
       "uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
       "title": "Non existing document",
       "metadata": [
@@ -178,9 +166,146 @@ Expected output.
 * Content-Type: "application/json"
 * Data[0].message: "Test document bulk CUD updated"
 * Data[0].uuid: {doc_uuid1}
+* Data[1].error.status: 400
+* Data[1].error.message: "Title is required"
+* Data[2].error.status: 404
+* Data[2].error.message: "Document does not exist"
+
+## GET /documents/test-document-bulk-cud/{doc_uuid1}
+
+Check the `title` and `field_id` of the first document have been updated.
+
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+Expected output.
+
+```json
+{
+  "uuid": "{doc_uuid1}",
+  "title": "Doc1 with new label",
+  "{field_id}": "doc1_new"
+}
+```
+
+* Status: `200`
+* Content-Type: "application/json"
+
+## PATCH /documents/test-document-bulk-cud/bulk
+
+Update (partially) documents in bulk.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "author": "Author",
+  "documents": [
+    {
+      "uuid": "{doc_uuid2}",
+      "metadata": [
+        {
+          "{field_id}": "doc2_new"
+        }
+      ]
+    },
+    {
+      "uuid": "{doc_uuid3}",
+      "metadata": [
+        {
+          "{field_id}": "doc3_new"
+        }
+      ]
+    }
+  ]
+}
+```
+
+===
+
+Expected output.
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data[0].message: "Test document bulk CUD updated"
+* Data[0].uuid: {doc_uuid2}
+* Data[1].message: "Test document bulk CUD updated"
+* Data[1].uuid: {doc_uuid3}
+
+## GET /documents/test-document-bulk-cud/{doc_uuid3}
+
+Check the `field_id` of the third document has been updated and that the
+`title` is still the same.
+
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+Expected output.
+
+```json
+{
+  "uuid": "{doc_uuid3}",
+  "title": "Doc3",
+  "{field_id}": "doc3_new"
+}
+```
+
+* Status: `200`
+* Content-Type: "application/json"
+
+## DELETE /documents/test-document-bulk-cud/bulk
+
+Delete elements in bulk.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "author": "Author",
+  "documents": [
+    {
+      "uuid": "{doc_uuid3}"
+    },
+    {
+      "uuid": "{doc_uuid4}"
+    },
+    {
+      "uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    }
+  ]
+}
+```
+
+===
+
+Expected output.
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data[0].message: "Test document bulk CUD deleted"
+* Data[0].uuid: {doc_uuid3}
 * Data[1].message: "Test document bulk CUD deleted"
 * Data[1].uuid: {doc_uuid4}
-* Data[2].message: "Test document bulk CUD created"
-* Data[2].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc5 uuid {doc_uuid5}
-* Data[3].error.status: 404
-* Data[3].error.message: "Document does not exist"
+* Data[2].error.status: 404
+* Data[2].error.message: "Document does not exist"
+
+## GET /documents/test-document-bulk-cud/{doc_uuid4}
+
+Check that the fourth document doesn't exist anymore.
+
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+Expected output.
+
+* Status: `404`

--- a/tests/silk_vocabulary_bulk_cud.md
+++ b/tests/silk_vocabulary_bulk_cud.md
@@ -191,10 +191,9 @@ Example output.
 * Content-Type: "application/json"
 
 
-## POST /vocabularies/{machine_name}/terms/bulk
+## PUT /vocabularies/{machine_name}/terms/bulk
 
-Update an existing term, delete an existing term, create new term and attempt to
-update a non existing term in the same request.
+Update terms in bulk. This is a full update so the `label` is mandatory.
 
 * Content-Type: "application/json"
 * Accept: "application/json"
@@ -205,35 +204,28 @@ update a non existing term in the same request.
   "author": "Author",
   "terms": [
     {
-      "_action": "update",
       "uuid": "{term_uuid1}",
       "label": "Term1 with new label",
       "metadata": [
         {
-          "{field_iso3}": "AFG"
+          "{field_iso3}": "FFF"
         }
       ]
     },
     {
-      "_action": "delete",
-      "uuid": "{term_uuid4}"
-    },
-    {
-      "_action": "create",
-      "label": "Term5",
+      "uuid": "{term_uuid2}",
       "metadata": [
         {
-          "{field_iso3}": "AFG"
+          "{field_iso3}": "GGGG"
         }
       ]
     },
     {
-      "_action": "update",
       "uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
       "label": "Non existing term",
       "metadata": [
         {
-          "{field_iso3}": "AFG"
+          "{field_iso3}": "nothing"
         }
       ]
     }
@@ -249,9 +241,146 @@ Expected output.
 * Content-Type: "application/json"
 * Data[0].message: "Term updated"
 * Data[0].uuid: {term_uuid1}
+* Data[1].error.status: 400
+* Data[1].error.message: "Label is required"
+* Data[2].error.status: 404
+* Data[2].error.message: "Term does not exist"
+
+## GET /vocabularies/{machine_name}/terms/{term_uuid1}
+
+Check the `label` and `field_iso3` of the first term have been updated.
+
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+Expected output.
+
+```json
+{
+  "uuid": "{term_uuid1}",
+  "label": "Term1 with new label",
+  "{field_iso3}": "FFF"
+}
+```
+
+* Status: `200`
+* Content-Type: "application/json"
+
+## PATCH /vocabularies/{machine_name}/terms/bulk
+
+Update (partially) terms in bulk.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "author": "Author",
+  "terms": [
+    {
+      "uuid": "{term_uuid2}",
+      "metadata": [
+        {
+          "{field_iso3}": "HHH"
+        }
+      ]
+    },
+    {
+      "uuid": "{term_uuid3}",
+      "metadata": [
+        {
+          "{field_iso3}": "III"
+        }
+      ]
+    }
+  ]
+}
+```
+
+===
+
+Expected output.
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data[0].message: "Term updated"
+* Data[0].uuid: {term_uuid2}
+* Data[1].message: "Term updated"
+* Data[1].uuid: {term_uuid3}
+
+## GET /vocabularies/{machine_name}/terms/{term_uuid3}
+
+Check the `field_iso3` of the third term has been updated and that the
+`label` is still the same.
+
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+Expected output.
+
+```json
+{
+  "uuid": "{term_uuid3}",
+  "label": "Term3",
+  "{field_iso3}": "III"
+}
+```
+
+* Status: `200`
+* Content-Type: "application/json"
+
+## DELETE /vocabularies/{machine_name}/terms/bulk
+
+Delete elements in bulk.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "author": "Author",
+  "terms": [
+    {
+      "uuid": "{term_uuid3}"
+    },
+    {
+      "uuid": "{term_uuid4}"
+    },
+    {
+      "uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    }
+  ]
+}
+```
+
+===
+
+Expected output.
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data[0].message: "Term deleted"
+* Data[0].uuid: {term_uuid3}
 * Data[1].message: "Term deleted"
 * Data[1].uuid: {term_uuid4}
-* Data[2].message: "Term created"
-* Data[2].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Doc5 uuid {term_uuid5}
-* Data[3].error.status: 404
-* Data[3].error.message: "Term does not exist"
+* Data[2].error.status: 404
+* Data[2].error.message: "Term does not exist"
+
+## GET /vocabularies/{machine_name}/terms/{term_uuid4}
+
+Check that the fourth term doesn't exist anymore.
+
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+Expected output.
+
+* Status: `404`


### PR DESCRIPTION
Ticket: DOC-22

Follow-up of https://github.com/UN-OCHA/docstore-site/pull/80 allowing POST, PUT, PATCH and DELETE methods on the BULK endpoints rather than using an `_action` property on the elements.

@attiks, please merge this PR to update #80 (it's against `feature/doc-22-bulk`) if you think that approach is better than the `_action` version.