### PR TITLE
Change travis to build docker image and run tests from it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,21 @@ php:
 services:
   - docker
 
+# Make sure we have a recent version of docker.
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 before_script:
   # Ensure the PHP environment is ready.
   - phpenv rehash
 
 script:
+  # Get docker information.
+  - docker -v
+  - docker-composer -v
+
   # PHP linting
   - test ! -d ./html/modules/custom || find -L ./html/modules/custom -iregex '.*\.\(php\|module\|inc\|install\)$' -print0 | xargs -0 -n 1 -P 4 php -l
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,82 +1,40 @@
 dist: trusty
 language: php
-cache:
-  - $HOME/.composer/cache
-  - solr_downloads
 
 php:
   - 7.3
 
-mysql:
-  database: drupal
-  username: root
-  encoding: utf8
-
-env:
-  global:
-     - DRUPAL_REPO='git://drupalcode.org/project/drupal.git'
-     - DRUPAL_VERSION='8.x'
-     - DRUSH_VERSION='8.*'
-     - PHPCS_VERSION='2.9.*@dev'
-     - CODER_VERSION='dev-8.x-2.x'
-     - DB=sqlite
-     - SOLR_VERSION=7.5.0
+services:
+  - docker
 
 before_script:
-  # Composer.
-  - sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc
-  - source $HOME/.bashrc
-  - composer self-update --1
-
   # Ensure the PHP environment is ready.
   - phpenv rehash
-
-  # Code sniff
-  - cd $TRAVIS_BUILD_DIR
-  - composer install
-
-  # Solr
-  - ls solr_downloads/
-  - wget -nc --continue -v --tries=3 --directory-prefix=solr_downloads "http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
-  - tar -xzf solr_downloads/solr-${SOLR_VERSION}.tgz
 
 script:
   # PHP linting
   - test ! -d ./html/modules/custom || find -L ./html/modules/custom -iregex '.*\.\(php\|module\|inc\|install\)$' -print0 | xargs -0 -n 1 -P 4 php -l
 
-  # PHP CS
-  - ./vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
-  - test ! -d ./html/modules/custom || ./vendor/bin/phpcs -p --report=full ./html/modules/custom
+  # Build local image.
+  - make
 
-  # Solr
-  - export SOLR_INDEX_WAIT=4
-  - $TRAVIS_BUILD_DIR/solr-${SOLR_VERSION}/bin/solr start -e techproducts || travis_terminate 1;
-  - $TRAVIS_BUILD_DIR/solr-${SOLR_VERSION}/bin/solr create -c d8 -d $TRAVIS_BUILD_DIR/tests/solr/ || travis_terminate 1;
+  # Create the site, solr and mysql containers.
+  - docker-compose -f tests/docker-compose.yml up -d
 
-  # Drupal install
-  - mysql -e "CREATE DATABASE drupal;"
-  - mysql -e "GRANT ALL ON drupal.* to drupal@127.0.0.1 IDENTIFIED BY 'drupal';"
+  # Dump some information about the created containers.
+  - docker ps -a
 
-  - cd ${TRAVIS_BUILD_DIR}
-  - mkdir -p ./html/sites/default
-  - mkdir -p ./private_files
-  - cp ./tests/default.se* ./html/sites/default/
-  - cp ./tests/default.settings.php ./html/sites/default/settings.php
-  - cp ./tests/settings.local.php ./html/sites/default/
-  - cp ./tests/config/* ./config/
+  # Wait a bit for solr and mysql to be ready.
+  - sleep 10
 
-  - cd ${TRAVIS_BUILD_DIR}/html
-  - ../vendor/bin/drush -y si --db-url=mysql://drupal:drupal@127.0.0.1/drupal minimal
-  - ../vendor/bin/drush -y cset system.site uuid $(grep uuid ${TRAVIS_BUILD_DIR}/config/system.site.yml | awk '{print $2}')
-  - ../vendor/bin/drush -y cim --source=${TRAVIS_BUILD_DIR}/config
-  - ../vendor/bin/drush rs 127.0.0.1:8080 >/dev/null 2>&1 &
-  - ../vendor/bin/drush -y en dblog
-  - ../vendor/bin/drush cr
-  - sleep 5
+  # Install the site with the existing config.
+  - docker exec -it docstore-travis-test drush -y si --existing-config
 
-  # Test
-  - cd ${TRAVIS_BUILD_DIR}/tests
-  - DRUSH="../vendor/bin/drush" HOST="http://127.0.0.1:8080" ./run.sh
+  # Check coding standards.
+  - docker exec -it -u appuser -w /srv/www docstore-travis-site ./vendor/bin/phpcs -p --report=full --standard=phpcs.xml ./html/modules/custom
+
+  # Run API tests.
+  - docker exec -it -u appuser -w /srv/www/tests -e HOST="http://docstore-travis-site" -e DRUSH="drush -v"  docstore-travis-site sh ./run.sh
 
 after_success:
   - echo "The tests completed without errors."

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_script:
 
 script:
   # Get docker information.
-  - docker -v
-  - docker-composer -v
+  - docker version
+  - docker-compose version
 
   # PHP linting
   - test ! -d ./html/modules/custom || find -L ./html/modules/custom -iregex '.*\.\(php\|module\|inc\|install\)$' -print0 | xargs -0 -n 1 -P 4 php -l

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ script:
   # Install the site with the existing config.
   - docker exec -it docstore-travis-site drush -y si --existing-config
 
+  # Ensure the file directories are writable.
+  - docker exec -it docstore-travis-site chmod -R 777 /srv/www/html/sites/default/files /srv/www/html/sites/default/private
+
   # Check coding standards.
   - docker exec -it -u appuser -w /srv/www docstore-travis-site ./vendor/bin/phpcs -p --report=full --standard=phpcs.xml ./html/modules/custom
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - sleep 10
 
   # Install the site with the existing config.
-  - docker exec -it docstore-travis-test drush -y si --existing-config
+  - docker exec -it docstore-travis-site drush -y si --existing-config
 
   # Check coding standards.
   - docker exec -it -u appuser -w /srv/www docstore-travis-site ./vendor/bin/phpcs -p --report=full --standard=phpcs.xml ./html/modules/custom

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,17 +3,12 @@ version: "2.2"
 networks:
   default:
 
-#volumes:
-#  docstore-travis-solr-data:
-
 services:
   solr:
     image: unocha/alpine-solr:8.1.1-201907-02
     hostname: docstore-travis-solr
     container_name: docstore-travis-solr
     volumes:
-    #  - "./solr_jetty/jetty.xml:/srv/solr/server/etc/jetty.xml:ro"
-    #  - "docstore-travis-solr-data:/srv/data"
       - "./solr:/srv/confs:ro"
     environment:
       - SOLR_CORE=search_api_solr_8.x-3.0
@@ -39,30 +34,10 @@ services:
     hostname: docstore-travis-site
     container_name: docstore-travis-site
     volumes:
-      # This mounts the site codebase repository.
-      - "../config:/srv/www/config:ro"
-      - "../drop_folder:/srv/www/drop_folder:ro"
-      - "../html/modules/custom:/srv/www/html/modules/custom:ro"
-      - "../tests:/srv/www/tests:ro"
-      - "../vendor:/srv/www/vendor:ro"
-      - "../composer.json:/srv/www/composer.json:ro"
-      - "../composer.lock:/srv/www/composer.lock:ro"
-      - "../composer.patches.json:/srv/www/composer.patches.json:ro"
-      - "../phpcs.xml:/srv/www/phpcs.xml:ro"
-      #- "../shared/files:/srv/www/html/sites/default/files:rw"
-      #- "../shared/private:/srv/www/html/sites/default/private:rw"
-      - "../docker/etc/nginx/map_block_http_methods.conf:/etc/nginx/map_block_http_methods.conf:ro"
-      - "../docker/etc/nginx/apps/drupal/drupal.conf:/etc/nginx/apps/drupal/drupal.conf:ro"
-      - "../docker/etc/nginx/apps/drupal/fastcgi_drupal.conf:/etc/nginx/apps/drupal/fastcgi_drupal.conf:ro"
       - "./settings:/srv/www/shared/settings:ro"
     environment:
       - TERM=xterm
       - ENVIRONMENT=dev
-      #- LISTEN_PORT=80
-      #- VIRTUAL_HOST=docstore-travis.test
-      #- VIRTUAL_PORT=80
-      #- VIRTUAL_NETWORK=nginx-proxy
-      #- HTTPS_METHOD=noredirect
       - NGINX_SERVERNAME=docstore-travis-site,localhost,127.0.0.1
       - NGINX_OVERRIDE_PROTOCOL=HTTP,docstore-travis-site,localhost,127.0.0.1
       - DRUSH_OPTIONS_URI=http://docstore-travis-site

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - "docstore-site-public:/srv/www/html/sites/default/files:rw"
       - "docstore-site-private:/srv/www/html/sites/default/private:rw"
       # Mount the folders needed for the tests.
-      - "../drop_folder:/srv/www/drop_folder:ro"
+      - "../drop_folders:/srv/www/drop_folders:ro"
       - "../tests:/srv/www/tests:ro"
       - "../phpcs.xml:/srv/www/phpcs.xml:ro"
     environment:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,6 +3,10 @@ version: "2.2"
 networks:
   default:
 
+volumes:
+  docstore-site-public:
+  docstore-site-private:
+
 services:
   solr:
     image: unocha/alpine-solr:8.1.1-201907-02
@@ -33,6 +37,9 @@ services:
     container_name: docstore-travis-site
     volumes:
       - "./settings:/srv/www/shared/settings:ro"
+      # Mount volumes for the private and public files.
+      - "docstore-site-public:/srv/www/html/sites/default/files:rw"
+      - "docstore-site-private:/srv/www/html/sites/default/private:rw"
       # Mount the folders needed for the tests.
       - "../drop_folder:/srv/www/drop_folder:ro"
       - "../tests:/srv/www/tests:ro"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,78 @@
+version: "2.2"
+
+networks:
+  default:
+
+#volumes:
+#  docstore-travis-solr-data:
+
+services:
+  solr:
+    image: unocha/alpine-solr:8.1.1-201907-02
+    hostname: docstore-travis-solr
+    container_name: docstore-travis-solr
+    volumes:
+    #  - "./solr_jetty/jetty.xml:/srv/solr/server/etc/jetty.xml:ro"
+    #  - "docstore-travis-solr-data:/srv/data"
+      - "./solr:/srv/confs:ro"
+    environment:
+      - SOLR_CORE=search_api_solr_8.x-3.0
+      - CORE=search_api_solr_8.x-3.0
+    networks:
+      - default
+
+  mysql:
+    image: unocha/alpine-mysql:10.4.13-r0-202006-01
+    hostname: docstore-travis-mysql
+    container_name: docstore-travis-mysql
+    environment:
+      - MYSQL_DB=docstore
+      - MYSQL_USER=docstore
+      - MYSQL_PASS=docstore
+    networks:
+      default:
+        aliases:
+          - mysql.docstore
+
+  drupal:
+    image: unocha/docstore-site:local
+    hostname: docstore-travis-site
+    container_name: docstore-travis-site
+    volumes:
+      # This mounts the site codebase repository.
+      - "../config:/srv/www/config:ro"
+      - "../drop_folder:/srv/www/drop_folder:ro"
+      - "../html/modules/custom:/srv/www/html/modules/custom:ro"
+      - "../tests:/srv/www/tests:ro"
+      - "../vendor:/srv/www/vendor:ro"
+      - "../composer.json:/srv/www/composer.json:ro"
+      - "../composer.lock:/srv/www/composer.lock:ro"
+      - "../composer.patches.json:/srv/www/composer.patches.json:ro"
+      - "../phpcs.xml:/srv/www/phpcs.xml:ro"
+      #- "../shared/files:/srv/www/html/sites/default/files:rw"
+      #- "../shared/private:/srv/www/html/sites/default/private:rw"
+      - "../docker/etc/nginx/map_block_http_methods.conf:/etc/nginx/map_block_http_methods.conf:ro"
+      - "../docker/etc/nginx/apps/drupal/drupal.conf:/etc/nginx/apps/drupal/drupal.conf:ro"
+      - "../docker/etc/nginx/apps/drupal/fastcgi_drupal.conf:/etc/nginx/apps/drupal/fastcgi_drupal.conf:ro"
+      - "./settings:/srv/www/shared/settings:ro"
+    environment:
+      - TERM=xterm
+      - ENVIRONMENT=dev
+      #- LISTEN_PORT=80
+      #- VIRTUAL_HOST=docstore-travis.test
+      #- VIRTUAL_PORT=80
+      #- VIRTUAL_NETWORK=nginx-proxy
+      #- HTTPS_METHOD=noredirect
+      - NGINX_SERVERNAME=docstore-travis-site,localhost,127.0.0.1
+      - NGINX_OVERRIDE_PROTOCOL=HTTP,docstore-travis-site,localhost,127.0.0.1
+      - DRUSH_OPTIONS_URI=http://docstore-travis-site
+      - DRUPAL_DB_DATABASE=docstore
+      - DRUPAL_DB_USERNAME=docstore
+      - DRUPAL_DB_PASSWORD=docstore
+      - DRUPAL_DB_HOST=localhost
+      - DRUPAL_DB_DRIVER=mysql
+    networks:
+      - default
+    depends_on:
+      - mysql
+      - solr

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -25,9 +25,7 @@ services:
       - MYSQL_USER=docstore
       - MYSQL_PASS=docstore
     networks:
-      default:
-        aliases:
-          - mysql.docstore
+      - default
 
   drupal:
     image: unocha/docstore-site:local
@@ -44,7 +42,7 @@ services:
       - DRUPAL_DB_DATABASE=docstore
       - DRUPAL_DB_USERNAME=docstore
       - DRUPAL_DB_PASSWORD=docstore
-      - DRUPAL_DB_HOST=localhost
+      - DRUPAL_DB_HOST=mysql
       - DRUPAL_DB_DRIVER=mysql
     networks:
       - default

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -33,6 +33,10 @@ services:
     container_name: docstore-travis-site
     volumes:
       - "./settings:/srv/www/shared/settings:ro"
+      # Mount the folders needed for the tests.
+      - "../drop_folder:/srv/www/drop_folder:ro"
+      - "../tests:/srv/www/tests:ro"
+      - "../phpcs.xml:/srv/www/phpcs.xml:ro"
     environment:
       - TERM=xterm
       - ENVIRONMENT=dev

--- a/tests/settings/services.yml
+++ b/tests/settings/services.yml
@@ -1,0 +1,49 @@
+# Local development services.
+#
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
+parameters:
+  http.response.debug_cacheability_headers: false
+  twig.config:
+    # Twig debugging:
+    #
+    # When debugging is enabled:
+    # - The markup of each Twig template is surrounded by HTML comments that
+    #   contain theming information, such as template file name suggestions.
+    # - Note that this debugging markup will cause automated tests that directly
+    #   check rendered HTML to fail. When running automated tests, 'debug'
+    #   should be set to FALSE.
+    # - The dump() function can be used in Twig templates to output information
+    #   about template variables.
+    # - Twig templates are automatically recompiled whenever the source code
+    #   changes (see auto_reload below).
+    #
+    # For more information about debugging Twig templates, see
+    # https://www.drupal.org/node/1906392.
+    #
+    # Not recommended in production environments
+    # @default false
+    debug: false
+    # Twig auto-reload:
+    #
+    # Automatically recompile Twig templates whenever the source code changes.
+    # If you don't provide a value for auto_reload, it will be determined
+    # based on the value of debug.
+    #
+    # Not recommended in production environments
+    # @default null
+    auto_reload: false
+    # Twig cache:
+    #
+    # By default, Twig templates will be compiled and stored in the filesystem
+    # to increase performance. Disabling the Twig cache will recompile the
+    # templates from source each time they are used. In most cases the
+    # auto_reload setting above should be enabled rather than disabling the
+    # Twig cache.
+    #
+    # Not recommended in production environments
+    # @default true
+    cache: true
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/tests/settings/settings.test.php
+++ b/tests/settings/settings.test.php
@@ -1,0 +1,145 @@
+<?php
+
+// @codingStandardsIgnoreFile
+
+/**
+ * @file
+ * Local development override configuration feature.
+ *
+ * To activate this feature, copy and rename it such that its path plus
+ * filename is 'sites/default/settings.local.php'. Then, go to the bottom of
+ * 'sites/default/settings.php' and uncomment the commented lines that mention
+ * 'settings.local.php'.
+ *
+ * If you are using a site name in the path, such as 'sites/example.com', copy
+ * this file to 'sites/example.com/settings.local.php', and uncomment the lines
+ * at the bottom of 'sites/example.com/settings.php'.
+ */
+
+/**
+ * Assertions.
+ *
+ * The Drupal project primarily uses runtime assertions to enforce the
+ * expectations of the API by failing when incorrect calls are made by code
+ * under development.
+ *
+ * @see http://php.net/assert
+ * @see https://www.drupal.org/node/2492225
+ *
+ * If you are using PHP 7.0 it is strongly recommended that you set
+ * zend.assertions=1 in the PHP.ini file (It cannot be changed from .htaccess
+ * or runtime) on development machines and to 0 in production.
+ *
+ * @see https://wiki.php.net/rfc/expectations
+ */
+assert_options(ASSERT_ACTIVE, TRUE);
+\Drupal\Component\Assertion\Handle::register();
+
+/**
+ * Enable local development services.
+ */
+$settings['container_yamls'][] = '/srv/www/shared/settings/services.yml';
+
+/**
+ * Show all error messages, with backtrace information.
+ *
+ * In case the error level could not be fetched from the database, as for
+ * example the database connection failed, we rely only on this value.
+ */
+$config['system.logging']['error_level'] = 'verbose';
+
+/**
+ * Disable CSS and JS aggregation.
+ */
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+
+/**
+ * Disable the render cache.
+ *
+ * Note: you should test with the render cache enabled, to ensure the correct
+ * cacheability metadata is present. However, in the early stages of
+ * development, you may want to disable it.
+ *
+ * This setting disables the render cache by using the Null cache back-end
+ * defined by the development.services.yml file above.
+ *
+ * Only use this setting once the site has been installed.
+ */
+# $settings['cache']['bins']['render'] = 'cache.backend.null';
+
+/**
+ * Disable caching for migrations.
+ *
+ * Uncomment the code below to only store migrations in memory and not in the
+ * database. This makes it easier to develop custom migrations.
+ */
+# $settings['cache']['bins']['discovery_migration'] = 'cache.backend.memory';
+
+/**
+ * Disable Internal Page Cache.
+ *
+ * Note: you should test with Internal Page Cache enabled, to ensure the correct
+ * cacheability metadata is present. However, in the early stages of
+ * development, you may want to disable it.
+ *
+ * This setting disables the page cache by using the Null cache back-end
+ * defined by the development.services.yml file above.
+ *
+ * Only use this setting once the site has been installed.
+ */
+# $settings['cache']['bins']['page'] = 'cache.backend.null';
+
+/**
+ * Disable Dynamic Page Cache.
+ *
+ * Note: you should test with Dynamic Page Cache enabled, to ensure the correct
+ * cacheability metadata is present (and hence the expected behavior). However,
+ * in the early stages of development, you may want to disable it.
+ */
+# $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+/**
+ * Allow test modules and themes to be installed.
+ *
+ * Drupal ignores test modules and themes by default for performance reasons.
+ * During development it can be useful to install test extensions for debugging
+ * purposes.
+ */
+# $settings['extension_discovery_scan_tests'] = TRUE;
+
+/**
+ * Enable access to rebuild.php.
+ *
+ * This setting can be enabled to allow Drupal's php and database cached
+ * storage to be cleared via the rebuild.php page. Access to this page can also
+ * be gained by generating a query string from rebuild_token_calculator.sh and
+ * using these parameters in a request to rebuild.php.
+ */
+$settings['rebuild_access'] = TRUE;
+
+/**
+ * Skip file system permissions hardening.
+ *
+ * The system module will periodically check the permissions of your site's
+ * site directory to ensure that it is not writable by the website user. For
+ * sites that are managed with a version control system, this can cause problems
+ * when files in that directory such as settings.php are updated, because the
+ * user pulling in the changes won't have permissions to modify files in the
+ * directory.
+ */
+$settings['skip_permissions_hardening'] = TRUE;
+
+// Workaround for permission issues with NFS shares
+$settings['file_chmod_directory'] = 0777;
+$settings['file_chmod_file'] = 0666;
+
+# File system settings.
+$config['system.file']['path']['temporary'] = '/tmp';
+$settings['file_private_path'] = '/srv/www/html/sites/default/private';
+
+// Default sync directory.
+$settings['config_sync_directory'] = '/srv/www/config';
+
+// Hash salt.
+$settings['hash_salt'] = 'doscstore-salt';


### PR DESCRIPTION
This PR changes the travis config to build an image with the latest code and run the tests inside a container using that image.

This is notably to be able to tests changes made to nginx to handle access to files which the tests rely on.

This also has the advantage of being closer to what is on production.