### PR TITLE
[OPS-7373] Add endpoint to check for private file access

### DIFF
--- a/docker/etc/nginx/custom/01_docstore_files.conf
+++ b/docker/etc/nginx/custom/01_docstore_files.conf
@@ -1,5 +1,6 @@
 ## Download handler.
 location ~ "^/files/([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/([^/]+)(\.[0-9a-zA-Z]+)$" {
+  set $docstore_media_uuid "$1$2$3";
   set $docstore_media_path "$1/$2/$1$2$3$5";
   set $docstore_filename "$4$5";
 
@@ -40,24 +41,49 @@ location @docstore-private-file {
   ## Do not log 404 for missing files.
   log_not_found off;
 
-  ## Skip if no token or an invalid token was provided.
-  if ($docstore_provider_token = "") {
-    return 404;
-  }
-
   ## Path to the private files.
-  set $docstore_base_path "/sites/default/private/media/$docstore_provider_token";
+  set $docstore_base_path "/sites/default/private/media";
 
   ## Skip if the media is hidden for the provider.
   if (-f "$document_root$docstore_base_path/$docstore_version/hidden/$docstore_media_path") {
     return 404;
   }
 
+  ## Check if there is a private symlink specific to the provider.
+  set $docstore_file "$docstore_base_path/$docstore_version/$docstore_media_path";
+  if (-f "$document_root$docstore_file") {
+    rewrite ^.+$ /docstore-private-file last;
+  }
+
+  ## Check if there is a private symlink for the latest version.
+  set $docstore_file "$docstore_base_path/latest/$docstore_media_path";
+  if (-f "$document_root$docstore_file") {
+    rewrite ^.+$ /docstore-private-file last;
+  }
+
+  return 404;
+}
+
+## Return the content of a private file after checking access.
+location = /docstore-private-file {
+  internal;
+
+  ## Check access to the media.
+  auth_request /docstore-private-file-access;
+
   ## Return the passed filename.
   add_header Content-Disposition 'attachment; filename="$docstore_filename"';
   add_header Cache-Control 'private';
 
-  ## Check if there is a symlink for the provider, otherwise attempt to serve
-  ## the latest version.
-  try_files "$docstore_base_path/$docstore_version/$docstore_media_path" "$docstore_base_path/latest/$docstore_media_path" =404;
+  try_files $docstore_file =404;
+}
+
+## Check access to the media.
+location = /docstore-private-file-access {
+  internal;
+
+  ## This returns a 200 if access is granted, 403 otherwise.
+  include apps/drupal/fastcgi_no_args_drupal.conf;
+  fastcgi_param REQUEST_URI "/api/v1/files/$docstore_media_uuid/access";
+  fastcgi_pass phpcgi;
 }

--- a/html/modules/custom/docstore/docstore.routing.yml
+++ b/html/modules/custom/docstore/docstore.routing.yml
@@ -655,6 +655,18 @@ docstore_delete_file:
     _auth: ['docstore_auth']
     docstore_crud: 'D'
     docstore_access_level: 'A'
+docstore_check_access_file:
+  path: '/api/v1/files/{uuid}/access'
+  defaults:
+    _controller: 'docstore.file_controller:checkFileAccess'
+    _title: 'Check if the provider has access to the file'
+  methods: [GET]
+  requirements:
+    _docstore_access_check: 'TRUE'
+  options:
+    _auth: ['docstore_auth']
+    docstore_crud: 'R'
+    docstore_access_level: 'B'
 docstore_get_file_usage:
   path: '/api/v1/files/{uuid}/usage'
   defaults:
@@ -759,8 +771,9 @@ docstore_download_file:
   defaults:
     _controller: 'docstore.download_controller:downloadFile'
     _title: 'Download a file'
-  methods: [GET]
   requirements:
-    _access: 'TRUE'
+    _docstore_access_check: 'TRUE'
   options:
+    _auth: ['docstore_auth']
     docstore_crud: 'R'
+    docstore_access_level: 'B'

--- a/html/modules/custom/docstore/src/FileTrait.php
+++ b/html/modules/custom/docstore/src/FileTrait.php
@@ -611,13 +611,10 @@ trait FileTrait {
         str_repeat($characters, 12),
       ]);
 
-      // Glob pattern for a hash.
-      $token_pattern = str_repeat($characters, 32);
-
       // Public and private path patterns.
       $bases = [
         'public' => $this->fileSystem->realpath('public://media'),
-        'private' => $this->fileSystem->realpath('private://media') . '/' . $token_pattern,
+        'private' => $this->fileSystem->realpath('private://media'),
       ];
 
       foreach ($bases as $type => $base) {
@@ -670,8 +667,7 @@ trait FileTrait {
 
     // Determine the base path for the symlinks based on the private state.
     if ($private) {
-      $token = $this->getProviderPrivateFileToken($owner);
-      $base = $this->fileSystem->realpath('private://media') . '/' . $token;
+      $base = $this->fileSystem->realpath('private://media');
     }
     else {
       $base = $this->fileSystem->realpath('public://media');
@@ -787,12 +783,9 @@ trait FileTrait {
       $link = $this->fileSystem->realpath('public://') . '/media';
     }
     // Otherwise if the provider is the owner, generate a symlink in the private
-    // directory with a token specific to the provider as part of the path.
-    // Nginx will ensure that the symlink can only be accessed if the same
-    // token is provided via the X-Docstore-Provider-Token header.
+    // directory.
     elseif ($this->providerIsOwner($media, $provider)) {
-      $token = $this->getProviderPrivateFileToken($provider);
-      $link = $this->fileSystem->realpath('private://') . '/media/' . $token;
+      $link = $this->fileSystem->realpath('private://') . '/media';
     }
     // Skip if the media is private and the provider is not the owner as it
     // means it doesn't have access to it.
@@ -883,7 +876,7 @@ trait FileTrait {
    *     the provider.
    */
   public function removeMediaSymlink(Media $media, UserInterface $provider, $type) {
-    $link = $this->generateSymlinkLink($media, $provider, 'provider-hidden');
+    $link = $this->generateSymlinkLink($media, $provider, $type);
     if (!empty($link)) {
       @unlink($link);
     }
@@ -911,22 +904,6 @@ trait FileTrait {
     if (!@symlink($target, $link)) {
       throw new HttpException(500, 'Unable to create link to file');
     }
-  }
-
-  /**
-   * Get the token used for the private symlinks.
-   *
-   * @param \Drupal\user\UserInterface $provider
-   *   Provider.
-   *
-   * @return string
-   *   Token.
-   */
-  public function getProviderPrivateFileToken(UserInterface $provider) {
-    // @phpstan-ignore-next-line
-    $api_key = $provider->get('api_keys')->value;
-    // @todo does that even makes sense as "secured" token?
-    return md5($api_key . $provider->uuid());
   }
 
   /**
@@ -959,11 +936,13 @@ trait FileTrait {
     $values = [];
     foreach ($selection as $provider_uuid => $target) {
       $values[] = [
-        'povider_uuid' => $provider_uuid,
+        'provider_uuid' => $provider_uuid,
         'target' => $target,
       ];
     }
-    $media->selected_file_versions->setValue($values);
+    $media->get('selected_file_versions')->setValue($values);
+    $media->setNewRevision(FALSE);
+    $media->save();
   }
 
   /**

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -72,10 +72,5 @@ $SILK -test.v -silk.url $API silk_exceptions.md || exit 1;
 # Reset docstore for testing.
 $DRUSH docstore:test-reset
 
-export PROVIDER_UUID1="$(curl -s -H "API-KEY: abcd" $API/me | get_uuid)"
-export PROVIDER_UUID2="$(curl -s -H "API-KEY: dcba" $API/me | get_uuid)"
-export PROVIDER_TOKEN1=$(php -r "print md5('abcd' . '$PROVIDER_UUID1');")
-export PROVIDER_TOKEN2=$(php -r "print md5('dbca' . '$PROVIDER_UUID2');")
-
 # Run direct download tests.
 $SILK -test.v -silk.url $HOST silk_files_direct.md || exit 1;

--- a/tests/silk_files_direct.md
+++ b/tests/silk_files_direct.md
@@ -1,5 +1,33 @@
 # Direct file access.
 
+## GET /api/v1/me
+
+Get the provider uuid for `provider_1`.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}$/ // UUID {provider_uuid_1}
+
+## GET /api/v1/me
+
+Get the provider uuid for `provider_2`.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: dcba
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}$/ // UUID {provider_uuid_2}
+
 ## POST /api/v1/files
 
 Create a public file `file_public_1` with content.
@@ -24,7 +52,7 @@ Note: the data is "Public file 1" encoded in base64.
 * Status: `201`
 * Content-Type: "application/json"
 * Data.message: "File created"
-* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // UUID {file_public_uuid_1}
+* Data.uuid: /^[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}$/ // UUID {file_public_uuid_1}
 
 ## POST /api/v1/files
 
@@ -50,7 +78,7 @@ Note: the data is "Private file 1" encoded in base64.
 * Status: `201`
 * Content-Type: "application/json"
 * Data.message: "File created"
-* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // UUID {file_private_uuid_1}
+* Data.uuid: /^[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}$/ // UUID {file_private_uuid_1}
 
 ## GET /files/not-a-uuid/pouet.txt
 
@@ -85,7 +113,7 @@ Public file 1
 
 Get the content of the public file `file_public_1` as a different provider
 
-* X-Docstore-Provider-Uuid: {PROVIDER_UUID2}
+* X-Docstore-Provider-Uuid: {provider_uuid_2}
 
 ===
 
@@ -100,7 +128,7 @@ Public file 1
 
 Get the content of the public file `file_public_1` as the owner
 
-* X-Docstore-Provider-Uuid: {PROVIDER_UUID1}
+* X-Docstore-Provider-Uuid: {provider_uuid_1}
 
 ===
 
@@ -125,6 +153,8 @@ extension.
 Get the content of the public file `file_public_1` as a different provider with
 the wrong extension.
 
+* X-Docstore-Provider-Uuid: {provider_uuid_2}
+
 ===
 
 * Status: `404`
@@ -134,6 +164,8 @@ the wrong extension.
 Get the content of the public file `file_public_1` as the owner with the wrong
 extension.
 
+* X-Docstore-Provider-Uuid: {provider_uuid_1}
+
 ===
 
 * Status: `404`
@@ -141,29 +173,29 @@ extension.
 
 ## GET /files/{file_private_uuid_1}/pouet.txt
 
-Get the content of the public file `file_public_1` as anonymous.
+Get the content of the private file `file_private_1` as anonymous.
 
 ===
 
-* Status: `404`
+* Status: `403`
 
 ## GET /files/{file_private_uuid_1}/pouet.txt
 
-Get the content of the public file `file_public_1` as a different provider.
+Get the content of the private file `file_private_1` as a different provider.
 
-* X-Docstore-Provider-Uuid: {PROVIDER_UUID2}
-* X-Docstore-Provider-Token: {PROVIDER_TOKEN2}
+* X-Docstore-Provider-Uuid: {provider_uuid_2}
+* API-KEY: dcba
 
 ===
 
-* Status: `404`
+* Status: `403`
 
 ## GET /files/{file_private_uuid_1}/pouet.txt
 
 Get the content of the private file `file_private_1` as the owner.
 
-* X-Docstore-Provider-Uuid: {PROVIDER_UUID1}
-* X-Docstore-Provider-Token: {PROVIDER_TOKEN1}
+* X-Docstore-Provider-Uuid: {provider_uuid_1}
+* API-KEY: abcd
 
 ===
 
@@ -188,8 +220,8 @@ extension.
 Get the content of the private file `file_private_1` as a different provider with
 the wrong extension.
 
-* X-Docstore-Provider-Uuid: {PROVIDER_UUID2}
-* X-Docstore-Provider-Token: {PROVIDER_TOKEN2}
+* X-Docstore-Provider-Uuid: {provider_uuid_2}
+* API-KEY: dcba
 
 ===
 
@@ -200,9 +232,286 @@ the wrong extension.
 Get the content of the private file `file_private_1` as the owner with the wrong
 extension.
 
-* X-Docstore-Provider-Uuid: {PROVIDER_UUID1}
-* X-Docstore-Provider-Token: {PROVIDER_TOKEN1}
+* X-Docstore-Provider-Uuid: {provider_uuid_1}
+* API-KEY: abcd
 
 ===
 
 * Status: `404`
+
+## GET /api/v1/files/{file_public_uuid_1}/revisions
+
+Get the revisions for the file.
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data[0].id: /.+/ // Id of the latest revision {file_public_revision_1}
+
+## PUT /api/v1/files/{file_public_uuid_1}/select
+
+Select the current version of the public file `file_public_1` for the second
+provider.
+
+* API-KEY: dcba
+
+```json
+{
+  "target": "{file_public_revision_1}"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "File version selected"
+
+
+## POST /api/v1/files/{file_public_uuid_1}/content
+
+Updat the content of the public file `file_public_1`.
+
+Note: the data is "Public file 1 - Updated" encoded in base64.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```txt
+Public file 1 - Updated
+
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "File content created"
+* Data.uuid: {file_public_uuid_1}
+
+## GET /api/v1/files/{file_public_uuid_1}/content
+
+Get the content of the public file `file_public_1` as anomymous
+
+===
+
+```txt
+Public file 1 - Updated
+
+```
+
+* Status: `200`
+
+## GET /api/v1/files/{file_public_uuid_1}/content
+
+Get the content of the public file `file_public_1` as another provider
+
+* API-KEY: dcba
+
+===
+
+```txt
+Public file 1 - Updated
+
+```
+
+* Status: `200`
+
+## GET /api/v1/files/{file_public_uuid_1}/content
+
+Get the content of the public file `file_public_1` as the owner
+
+* API-KEY: abcd
+
+===
+
+```txt
+Public file 1 - Updated
+
+```
+
+* Status: `200`
+
+## GET /files/{file_public_uuid_1}/pouet.txt
+
+Get the content of the public file `file_public_1` as anonymous.
+
+It should be the latest version.
+
+===
+
+```txt
+Public file 1 - Updated
+
+```
+
+* Status: `200`
+
+## GET /files/{file_public_uuid_1}/pouet.txt
+
+Get the content of the public file `file_public_1` as another provider.
+
+It should be the first version as it was selected for this provider.
+
+* X-Docstore-Provider-Uuid: {provider_uuid_2}
+
+===
+
+```txt
+Public file 1
+
+```
+
+* Status: `200`
+
+## GET /files/{file_public_uuid_1}/pouet.txt
+
+Get the content of the public file `file_public_1` as the owner.
+
+It should be the latest version.
+
+* X-Docstore-Provider-Uuid: {provider_uuid_1}
+
+===
+
+```txt
+Public file 1 - Updated
+
+```
+
+* Status: `200`
+
+## PUT /api/v1/files/{file_public_uuid_1}/select
+
+Select the latest version of the public file `file_public_1` for the second
+provider.
+
+* API-KEY: dcba
+
+```json
+{
+  "target": "latest"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "File version selected"
+
+## GET /files/{file_public_uuid_1}/pouet.txt
+
+Get the content of the public file `file_public_1` as anonymous.
+
+It should be the latest version.
+
+===
+
+```txt
+Public file 1 - Updated
+
+```
+
+* Status: `200`
+
+## GET /files/{file_public_uuid_1}/pouet.txt
+
+Get the content of the public file `file_public_1` as another provider.
+
+It should be the latest version.
+
+* X-Docstore-Provider-Uuid: {provider_uuid_2}
+
+===
+
+```txt
+Public file 1 - Updated
+
+```
+
+* Status: `200`
+
+## GET /files/{file_public_uuid_1}/pouet.txt
+
+Get the content of the public file `file_public_1` as the owner.
+
+It should be the latest version.
+
+* X-Docstore-Provider-Uuid: {provider_uuid_1}
+
+===
+
+```txt
+Public file 1 - Updated
+
+```
+
+* Status: `200`
+
+## PUT /api/v1/files/{file_public_uuid_1}/select
+
+Hide the public file `file_public_1` for the second provider.
+
+* API-KEY: dcba
+
+```json
+{
+  "target": "hidden"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "File version selected"
+
+## GET /files/{file_public_uuid_1}/pouet.txt
+
+Get the content of the public file `file_public_1` as anonymous.
+
+It should be the latest version.
+
+===
+
+```txt
+Public file 1 - Updated
+
+```
+
+* Status: `200`
+
+## GET /files/{file_public_uuid_1}/pouet.txt
+
+Get the content of the public file `file_public_1` as another provider.
+
+It should be a 404 not found.
+
+* X-Docstore-Provider-Uuid: {provider_uuid_2}
+
+===
+
+* Status: `404`
+
+## GET /files/{file_public_uuid_1}/pouet.txt
+
+Get the content of the public file `file_public_1` as the owner.
+
+It should be the latest version.
+
+* X-Docstore-Provider-Uuid: {provider_uuid_1}
+
+===
+
+```txt
+Public file 1 - Updated
+
+```
+
+* Status: `200`
+


### PR DESCRIPTION
Ticket: OPS-7373

*Note: this is not necessary for the Assessment Registry launch and only changes internally the way access to the private files is handled.*

Follow-up of https://github.com/UN-OCHA/docstore-site/pull/96 that changes the handling of private files.

This removes the symlinks with tokens for private files. Instead the docstore nginx calls an api endpoint to check if the provider has access to the file and if that's the case serves the file. 

That means that to access a private file, a client needs to add the `API-KEY` header to the request to the `/files` endpoint.

Symlinks are only used to connect a `media` to a `file`, with the possibility to point at a different version for a given provider.

