### PR TITLE
[AR-217] Create media after file entity has been saved so it has an id

### DIFF
--- a/html/modules/custom/docstore/src/Controller/FileController.php
+++ b/html/modules/custom/docstore/src/Controller/FileController.php
@@ -244,9 +244,6 @@ class FileController extends ControllerBase {
     /** @var \Drupal\file\Entity\File $file */
     $file = $this->createFileEntity($params['filename'], $params['mimetype'], $private, $provider);
 
-    // Create the media entity.
-    $media = $this->createMediaEntity($file, $private, $provider);
-
     // Case 1: binary content provided in the request params.
     if (!empty($params['data'])) {
       $content = base64_decode($params['data']);
@@ -262,12 +259,15 @@ class FileController extends ControllerBase {
 
     // Save the file's content if provided.
     if (!empty($content)) {
-      $this->saveFileToDisk($file, $content, $provider);
+      $file = $this->saveFileToDisk($file, $content, $provider);
     }
     // Otherwise we save the file without content.
     else {
       $file->save();
     }
+
+    // Create the media entity.
+    $media = $this->createMediaEntity($file, $private, $provider);
 
     // Save the media and generate the symlinks if possible.
     $this->saveMedia($media, $file, $provider);


### PR DESCRIPTION
Ticket: AR-217

This moves the media entity creation after the file entity has been saved when creating a file resource so that the file entity has an id.

This doesn't really do much aside of ensuring the first revision has the proper message: "File created" instead of "File updated" (see `FileTrait::saveMedia()`).