### PR TITLE
[DOC-59] Update webhooks

### DIFF
--- a/html/modules/custom/docstore/docstore.module
+++ b/html/modules/custom/docstore/docstore.module
@@ -294,30 +294,56 @@ function docstore_create_node_type($type = 'document', $endpoint = 'documents') 
  * Implements hook_webhooks_event_info_alter().
  */
 function docstore_webhooks_event_info_alter(&$options) {
-  $entities = [
-    'vocabulary',
-    'term',
-    'media',
-    'file',
-    'field:document',
-    'field:vocabulary',
+  $base_events = [
+    // Resource types.
+    'document_type' => 'Hook: document type',
+    'vocabulary' => 'Hook: vocabulary',
+    // Fields on resource types.
+    'field:document_type' => 'Hook: field on document type',
+    'field:vocabulary' => 'Hook: field on vocabulary',
+    // Individual resources.
+    'document' => 'Hook: document',
+    'term' => 'Hook: term',
+    'file' => 'Hook: file',
   ];
 
-  $entities = array_merge($entities, _docstore_get_defined_node_types());
+  $entity_type_manager = \Drupal::entityTypeManager();
+
+  // Get the list of node types.
+  $ids = $entity_type_manager
+    ->getStorage('node_type')
+    ->getQuery()
+    ->accessCheck(FALSE)
+    ->execute();
+  foreach ($ids as $id) {
+    $base_events['document:' . $id] = 'Hook: document ' . $id;
+  }
+
+  // Get the list of vocabularies.
+  $ids = $entity_type_manager
+    ->getStorage('taxonomy_vocabulary')
+    ->getQuery()
+    ->accessCheck(FALSE)
+    ->execute();
+  foreach ($ids as $id) {
+    $base_events['term:' . $id] = 'Hook: term ' . $id;
+  }
 
   $actions = [
     'create',
+    // @todo does it make sense to allow webhooks on read actions?
     'read',
     'update',
     'delete',
   ];
 
   $options = [];
-  foreach ($entities as $entity) {
+  foreach ($base_events as $base_event => $label) {
     foreach ($actions as $action) {
-      $options[$entity . ':' . $action] = [
-        'type' => 'Hook: ' . ucfirst($entity),
-        'event' => $entity . ':' . $action,
+      $event = $base_event . ':' . $action;
+      $options[$event] = [
+        'type' => $label . ' - ' . $action,
+        'event' => $event,
       ];
     }
   }

--- a/html/modules/custom/docstore/src/Controller/DocumentController.php
+++ b/html/modules/custom/docstore/src/Controller/DocumentController.php
@@ -452,6 +452,13 @@ class DocumentController extends ControllerBase {
     // Create document.
     $data = $this->createDocumentFromParameters($node_type, $params, $provider, TRUE);
 
+    // Notifiy webhooks.
+    docstore_notify_webhooks('document:' . $node_type->id() . ':create', $data['uuid']);
+    docstore_notify_webhooks('document:create', [
+      'uuid' => $data['uuid'],
+      'type' => $node_type->id(),
+    ]);
+
     return $this->createJsonResponse($data, 201);
   }
 
@@ -604,6 +611,13 @@ class DocumentController extends ControllerBase {
 
     // Update the document.
     $data = $this->updateDocumentFromParameters($node_type, $params, $provider, $request->getMethod() === 'PUT');
+
+    // Notifiy webhooks.
+    docstore_notify_webhooks('document:' . $node_type->id() . ':update', $data['uuid']);
+    docstore_notify_webhooks('document:update', [
+      'uuid' => $data['uuid'],
+      'type' => $node_type->id(),
+    ]);
 
     return $this->createJsonResponse($data, 200);
   }
@@ -768,6 +782,13 @@ class DocumentController extends ControllerBase {
 
     // Delete the document.
     $data = $this->deleteDocumentFromParameters($node_type, $params, $provider);
+
+    // Notifiy webhooks.
+    docstore_notify_webhooks('document:' . $node_type->id() . ':delete', $data['uuid']);
+    docstore_notify_webhooks('document:delete', [
+      'uuid' => $data['uuid'],
+      'type' => $node_type->id(),
+    ]);
 
     return $this->createJsonResponse($data, 200);
   }

--- a/html/modules/custom/docstore/src/Controller/DocumentTypeController.php
+++ b/html/modules/custom/docstore/src/Controller/DocumentTypeController.php
@@ -248,6 +248,9 @@ class DocumentTypeController extends ControllerBase {
       'message' => 'Document type created',
     ] + $this->buildDocumentTypeJsonOutput($node_type);
 
+    // Notify webhooks.
+    docstore_notify_webhooks('document_type:create', $node_type->id());
+
     return $this->createJsonResponse($data, 201);
   }
 
@@ -301,6 +304,9 @@ class DocumentTypeController extends ControllerBase {
       'message' => 'Document type updated',
     ] + $this->buildDocumentTypeJsonOutput($node_type);
 
+    // Notify webhooks.
+    docstore_notify_webhooks('document_type:update', $node_type->id());
+
     return $this->createJsonResponse($data, 200);
   }
 
@@ -339,6 +345,9 @@ class DocumentTypeController extends ControllerBase {
       'message' => strtr('@type deleted', ['@type' => $node_type->label()]),
       'uuid' => $node_type->uuid(),
     ];
+
+    // Notify webhooks.
+    docstore_notify_webhooks('document_type:delete', $node_type->id());
 
     return $this->createJsonResponse($data, 200);
   }
@@ -407,6 +416,12 @@ class DocumentTypeController extends ControllerBase {
       'message' => 'Field created',
       'field_name' => $field_name,
     ];
+
+    // Notify webhooks.
+    docstore_notify_webhooks('field:document_type:create', [
+      'field' => $field_name,
+      'document_type' => $node_type->id(),
+    ]);
 
     return $this->createJsonResponse($data, 201);
   }
@@ -480,6 +495,12 @@ class DocumentTypeController extends ControllerBase {
       'field_name' => $field_name,
     ];
 
+    // Notify webhooks.
+    docstore_notify_webhooks('field:document_type:update', [
+      'field' => $field_name,
+      'document_type' => $node_type->id(),
+    ]);
+
     return $this->createJsonResponse($data, 200);
   }
 
@@ -516,6 +537,12 @@ class DocumentTypeController extends ControllerBase {
       'message' => 'Field deleted',
       'field_name' => $field_name,
     ];
+
+    // Notify webhooks.
+    docstore_notify_webhooks('field:document_type:delete', [
+      'field' => $field_name,
+      'document_type' => $node_type->id(),
+    ]);
 
     return $this->createJsonResponse($data, 200);
   }

--- a/html/modules/custom/docstore/src/Controller/FileController.php
+++ b/html/modules/custom/docstore/src/Controller/FileController.php
@@ -277,6 +277,9 @@ class FileController extends ControllerBase {
       'message' => 'File created',
     ] + $this->prepareMediaEntityData($media, $file, $provider);
 
+    // Notifiy webhooks.
+    docstore_notify_webhooks('file:create', $data['uuid']);
+
     return $this->createJsonResponse($data, 201);
   }
 
@@ -385,6 +388,9 @@ class FileController extends ControllerBase {
       'message' => 'File updated',
     ] + $this->prepareMediaEntityData($media, $file, $provider, $revisions);
 
+    // Notifiy webhooks.
+    docstore_notify_webhooks('file:update', $data['uuid']);
+
     return $this->createJsonResponse($data, 200);
   }
 
@@ -439,6 +445,9 @@ class FileController extends ControllerBase {
       'message' => 'File deleted',
       'uuid' => $media->uuid(),
     ];
+
+    // Notifiy webhooks.
+    docstore_notify_webhooks('file:delete', $data['uuid']);
 
     return $this->createJsonResponse($data, 200);
   }
@@ -639,6 +648,9 @@ class FileController extends ControllerBase {
       'message' => 'File content created',
     ] + $this->prepareMediaEntityData($media, $file, $provider);
 
+    // Notifiy webhooks.
+    docstore_notify_webhooks('file:update', $data['uuid']);
+
     return $this->createJsonResponse($data, 200);
   }
 
@@ -751,6 +763,8 @@ class FileController extends ControllerBase {
    *
    * @todo allow removal of a revision by the owner regardless of whether it's
    * in use by another provider or not?
+   *
+   * @todo notify webhooks? What event?
    */
   public function deleteFileRevision($uuid, $revision_id, Request $request) {
     /** @var \Drupal\user\UserInterface $provider */

--- a/html/modules/custom/docstore/src/Controller/TermController.php
+++ b/html/modules/custom/docstore/src/Controller/TermController.php
@@ -317,6 +317,13 @@ class TermController extends ControllerBase {
     // Create the term.
     $data = $this->createTermFromParameters($vocabulary, $params, $provider, TRUE);
 
+    // Notifiy webhooks.
+    docstore_notify_webhooks('term:' . $vocabulary->id() . ':create', $data['uuid']);
+    docstore_notify_webhooks('term:create', [
+      'uuid' => $data['uuid'],
+      'vocabulary' => $vocabulary->id(),
+    ]);
+
     return $this->createJsonResponse($data, 201);
   }
 
@@ -452,6 +459,13 @@ class TermController extends ControllerBase {
 
     // Update the term.
     $data = $this->updateTermFromParameters($vocabulary, $params, $provider, $request->getMethod() === 'PUT');
+
+    // Notifiy webhooks.
+    docstore_notify_webhooks('term:' . $vocabulary->id() . ':update', $data['uuid']);
+    docstore_notify_webhooks('term:update', [
+      'uuid' => $data['uuid'],
+      'vocabulary' => $vocabulary->id(),
+    ]);
 
     return $this->createJsonResponse($data, 200);
   }
@@ -613,6 +627,13 @@ class TermController extends ControllerBase {
 
     // Delete the term.
     $data = $this->deleteTermFromParameters($vocabulary, $params, $provider);
+
+    // Notifiy webhooks.
+    docstore_notify_webhooks('term:' . $vocabulary->id() . ':delete', $data['uuid']);
+    docstore_notify_webhooks('term:delete', [
+      'uuid' => $data['uuid'],
+      'vocabulary' => $vocabulary->id(),
+    ]);
 
     return $this->createJsonResponse($data, 200);
   }

--- a/html/modules/custom/docstore/src/Controller/VocabularyController.php
+++ b/html/modules/custom/docstore/src/Controller/VocabularyController.php
@@ -260,6 +260,9 @@ class VocabularyController extends ControllerBase {
       'message' => 'Vocabulary created',
     ] + $this->buildVocabularyJsonOutput($vocabulary);
 
+    // Notifiy webhooks.
+    docstore_notify_webhooks('vocabulary:create', $vocabulary->id());
+
     return $this->createJsonResponse($data, 201);
   }
 
@@ -303,6 +306,9 @@ class VocabularyController extends ControllerBase {
       'uuid' => $vocabulary->uuid(),
     ];
 
+    // Notifiy webhooks.
+    docstore_notify_webhooks('vocabulary:update', $vocabulary->id());
+
     return $this->createJsonResponse($data, 200);
   }
 
@@ -345,6 +351,9 @@ class VocabularyController extends ControllerBase {
       'message' => 'Vocabulary deleted',
       'uuid' => $vocabulary->uuid(),
     ];
+
+    // Notifiy webhooks.
+    docstore_notify_webhooks('vocabulary:delete', $vocabulary->id());
 
     return $this->createJsonResponse($data, 200);
   }
@@ -447,6 +456,12 @@ class VocabularyController extends ControllerBase {
       'field_name' => $field_name,
     ];
 
+    // Notifiy webhooks.
+    docstore_notify_webhooks('field:vocabulary:create', [
+      'field' => $field_name,
+      'vocabulary' => $vocabulary->id(),
+    ]);
+
     return $this->createJsonResponse($data, 201);
   }
 
@@ -487,6 +502,12 @@ class VocabularyController extends ControllerBase {
       'field_name' => $field_name,
     ];
 
+    // Notifiy webhooks.
+    docstore_notify_webhooks('field:vocabulary:update', [
+      'field' => $field_name,
+      'vocabulary' => $vocabulary->id(),
+    ]);
+
     return $this->createJsonResponse($data, 200);
   }
 
@@ -523,6 +544,12 @@ class VocabularyController extends ControllerBase {
       'message' => 'Field deleted',
       'field_name' => $field_name,
     ];
+
+    // Notifiy webhooks.
+    docstore_notify_webhooks('field:vocabulary:delete', [
+      'field' => $field_name,
+      'vocabulary' => $vocabulary->id(),
+    ]);
 
     return $this->createJsonResponse($data, 200);
   }

--- a/html/modules/custom/docstore/src/ManageFields.php
+++ b/html/modules/custom/docstore/src/ManageFields.php
@@ -517,8 +517,6 @@ class ManageFields {
       }
     }
 
-    docstore_notify_webhooks('document_type:create', $machine_name);
-
     return $node_type;
   }
 
@@ -592,8 +590,6 @@ class ManageFields {
     }
 
     $node_type->save();
-
-    docstore_notify_webhooks('document_type:update', $type);
 
     return $node_type;
   }
@@ -716,9 +712,6 @@ class ManageFields {
     // Add to index.
     $this->addDocumentFieldToIndex($field_config, $label);
 
-    // Trigger webhook.
-    docstore_notify_webhooks('field:document:create', $field_name);
-
     return $field_name;
   }
 
@@ -812,7 +805,6 @@ class ManageFields {
       $this->addDocumentFieldToIndex($field_config, $label);
     }
 
-    docstore_notify_webhooks('field:document:create', $field_name);
     return $field_name;
   }
 
@@ -857,7 +849,6 @@ class ManageFields {
       $field_config->setThirdPartySetting('docstore', 'private', $params['private']);
     }
 
-    docstore_notify_webhooks('field:document:update', $field_name);
     $field_config->save();
 
     return $field_name;
@@ -874,7 +865,6 @@ class ManageFields {
       throw new NotFoundHttpException('Field does not exist');
     }
 
-    docstore_notify_webhooks('field:document:delete', $field_name);
     $field_storage->delete();
 
     return $field_name;
@@ -939,7 +929,6 @@ class ManageFields {
     // Add author HID.
     $this->createVocabularyBaseFieldHidId($machine_name);
 
-    docstore_notify_webhooks('vocabulary:create', $machine_name);
     return $vocabulary;
   }
 
@@ -1077,7 +1066,6 @@ class ManageFields {
 
     $vocabulary->save();
 
-    docstore_notify_webhooks('vocabulary:update', $vocabulary->id());
     return $vocabulary;
   }
 
@@ -1096,7 +1084,6 @@ class ManageFields {
       throw new \Exception('Vocabulary is not owned by you');
     }
 
-    docstore_notify_webhooks('vocabulary:delete', $vocabulary->id());
     $vocabulary->delete();
 
     return $vocabulary;
@@ -1200,7 +1187,6 @@ class ManageFields {
       $field_config->setThirdPartySetting('docstore', 'private', $params['private']);
     }
 
-    docstore_notify_webhooks('field:vocabulary:update', $field_name);
     $field_config->save();
 
     return $field_name;
@@ -1220,7 +1206,6 @@ class ManageFields {
       throw new NotFoundHttpException('Field does not exist');
     }
 
-    docstore_notify_webhooks('field:vocabulary:delete', $field_name);
     $field_config->delete();
 
     return $field_name;
@@ -1277,7 +1262,6 @@ class ManageFields {
       $this->addTermFieldToIndex($field_config, $label);
     }
 
-    docstore_notify_webhooks('field:vocabulary:create', $field_name);
     return $field_name;
   }
 
@@ -1339,7 +1323,6 @@ class ManageFields {
       $this->addTermFieldToIndex($field_config, $label);
     }
 
-    docstore_notify_webhooks('field:vocabulary:create', $field_name);
     return $field_name;
   }
 

--- a/tests/silk_webhooks.md
+++ b/tests/silk_webhooks.md
@@ -1,4 +1,4 @@
-# Create vocabularies
+# Test webhooks endpoints
 
 ## POST /webhooks
 
@@ -113,3 +113,1063 @@ Delete web hooks.
 * Status: `200`
 * Content-Type: "application/json"
 
+# Test webhook notifications
+
+## POST /webhooks
+
+Register a webhook.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "My local webhook",
+  "payload_url": "{WEBHOOK_SERVER_URL}",
+  "events": [
+    "document_type:create",
+    "document_type:update",
+    "document_type:delete",
+    "vocabulary:create",
+    "vocabulary:update",
+    "vocabulary:delete"
+  ]
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Webhook created"
+* Data.machine_name: /^[0-9a-z_]+$/ // Machine name {webhook}
+
+## POST /vocabularies
+
+Create vocabulary.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Test Vocabulary",
+  "author": "test"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Vocabulary created"
+* Data.machine_name: /^[0-9a-z_]+$/ // Machine_name {vocabulary}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the vocabulary creation.
+
+===
+
+```json
+[{
+  "event": "vocabulary:create",
+  "payload": "{vocabulary}"
+}]
+```
+
+## POST /types
+
+Create document type.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "machine_name": "test_dpcument_type",
+  "endpoint": "test-document-type",
+  "label": "Test document type",
+  "author": "test"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.machine_name: /.+/ // Machine name {doc_type}
+* Data.endpoint: /.+/ // Endpoint {doc_type_endpoint}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the document type creation
+
+===
+
+```json
+[{
+  "event": "document_type:create",
+  "payload": "{doc_type}"
+}]
+```
+
+## DELETE /webhooks/{webhook}
+
+Delete webhook.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+```json
+{
+  "message": "Webhook deleted"
+}
+```
+
+* Status: `200`
+* Content-Type: "application/json"
+
+## POST /webhooks
+
+Register a webhook.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "My local webhook",
+  "payload_url": "{WEBHOOK_SERVER_URL}",
+  "events": [
+    "document_type:create",
+    "document_type:update",
+    "document_type:delete",
+    "vocabulary:create",
+    "vocabulary:update",
+    "vocabulary:delete",
+    "field:document_type:create",
+    "field:document_type:update",
+    "field:document_type:delete",
+    "field:vocabulary:create",
+    "field:vocabulary:update",
+    "field:vocabulary:delete",
+    "document:create",
+    "document:update",
+    "document:delete",
+    "document:{doc_type}:create",
+    "document:{doc_type}:update",
+    "document:{doc_type}:delete",
+    "term:create",
+    "term:update",
+    "term:delete",
+    "term:{vocabulary}:create",
+    "term:{vocabulary}:update",
+    "term:{vocabulary}:delete",
+    "file:create",
+    "file:update",
+    "file:delete"
+  ]
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Webhook created"
+* Data.machine_name: /^[0-9a-z_]+$/ // Machine name {webhook}
+
+## POST /vocabularies/{vocabulary}/fields
+
+Add a field to vocabulary.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Test field",
+  "author": "test",
+  "type": "string"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Field created"
+* Data.field_name: /^[0-9a-z_]+$/ // Field name {vocabulary_field}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the vocabulary field creation.
+
+===
+
+```json
+[{
+  "event": "field:vocabulary:create",
+  "payload": {
+    "field": "{vocabulary_field}",
+    "vocabulary": "{vocabulary}"
+  }
+}]
+```
+
+## PATCH /vocabularies/{vocabulary}/fields/{vocabulary_field}
+
+Update vocabulary field
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Test field - Updated",
+  "author": "test"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "Field updated"
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the vocabulary field update.
+
+===
+
+```json
+[{
+  "event": "field:vocabulary:update",
+  "payload": {
+    "field": "{vocabulary_field}",
+    "vocabulary": "{vocabulary}"
+  }
+}]
+```
+
+## DELETE /vocabularies/{vocabulary}/fields/{vocabulary_field}
+
+Delete vocabulary field
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Test field",
+  "author": "test",
+  "type": "string"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "Field deleted"
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the vocabulary field deletion.
+
+===
+
+```json
+[{
+  "event": "field:vocabulary:delete",
+  "payload": {
+    "field": "{vocabulary_field}",
+    "vocabulary": "{vocabulary}"
+  }
+}]
+```
+
+## POST /vocabularies/{vocabulary}/terms
+
+Create a term.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Pouet",
+  "author": "test"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Term created"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Term uuid {term_uuid}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the term creation
+
+===
+
+```json
+[{
+  "event": "term:create",
+  "payload": {
+    "uuid": "{term_uuid}",
+    "vocabulary": "{vocabulary}"
+  }
+},
+{
+  "event": "term:{vocabulary}:create",
+  "payload": "{term_uuid}"
+}]
+```
+
+## PATCH /vocabularies/{vocabulary}/terms/{term_uuid}
+
+Update term.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Machin"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "Term updated"
+* Data.uuid: {term_uuid}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the term update.
+
+===
+
+```json
+[{
+  "event": "term:update",
+  "payload": {
+    "uuid": "{term_uuid}",
+    "vocabulary": "{vocabulary}"
+  }
+},
+{
+  "event": "term:{vocabulary}:update",
+  "payload": "{term_uuid}"
+}]
+```
+
+## DELETE /vocabularies/{vocabulary}/terms/{term_uuid}
+
+Delete term.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "Term deleted"
+* Data.uuid: {term_uuid}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the term deletion.
+
+===
+
+```json
+[{
+  "event": "term:delete",
+  "payload": {
+    "uuid": "{term_uuid}",
+    "vocabulary": "{vocabulary}"
+  }
+},
+{
+  "event": "term:{vocabulary}:delete",
+  "payload": "{term_uuid}"
+}]
+```
+
+## PATCH /vocabularies/{vocabulary}
+
+Update vocabulary.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Test vocabulary - Updated"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "Vocabulary updated"
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the vocabulary update.
+
+===
+
+```json
+[{
+  "event": "vocabulary:update",
+  "payload": "{vocabulary}"
+}]
+```
+
+## DELETE /vocabularies/{vocabulary}
+
+Delete vocabulary.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the vocabulary deletion.
+
+===
+
+```json
+[{
+  "event": "vocabulary:delete",
+  "payload": "{vocabulary}"
+}]
+```
+
+## POST /types/{doc_type}/fields
+
+Add a field to document type.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Test field",
+  "author": "test",
+  "type": "string"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Field created"
+* Data.field_name: /^[0-9a-z_]+$/ // Field name {doc_type_field}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the document type field creation.
+
+===
+
+```json
+[{
+  "event": "field:document_type:create",
+  "payload": {
+    "field": "{doc_type_field}",
+    "document_type": "{doc_type}"
+  }
+}]
+```
+
+## PATCH  /types/{doc_type}/fields/{doc_type_field}
+
+Update document type field
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Test field - Updated",
+  "author": "test"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "Field updated"
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the document type field update.
+
+===
+
+```json
+[{
+  "event": "field:document_type:update",
+  "payload": {
+    "field": "{doc_type_field}",
+    "document_type": "{doc_type}"
+  }
+}]
+```
+
+## DELETE  /types/{doc_type}/fields/{doc_type_field}
+
+Delete document type field
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Test field",
+  "author": "test",
+  "type": "string"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "Field deleted"
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the document type field deletion.
+
+===
+
+```json
+[{
+  "event": "field:document_type:delete",
+  "payload": {
+    "field": "{doc_type_field}",
+    "document_type": "{doc_type}"
+  }
+}]
+```
+
+## POST /documents/{doc_type_endpoint}
+
+Create a document.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Pouet",
+  "author": "test"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Term uuid {doc_uuid}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the document creation
+
+===
+
+```json
+[{
+  "event": "document:create",
+  "payload": {
+    "uuid": "{doc_uuid}",
+    "type": "{doc_type}"
+  }
+},
+{
+  "event": "document:{doc_type}:create",
+  "payload": "{doc_uuid}"
+}]
+```
+
+## PATCH /documents/{doc_type_endpoint}/{doc_uuid}
+
+Update document.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Machin"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.uuid: {doc_uuid}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the document update.
+
+===
+
+```json
+[{
+  "event": "document:update",
+  "payload": {
+    "uuid": "{doc_uuid}",
+    "type": "{doc_type}"
+  }
+},
+{
+  "event": "document:{doc_type}:update",
+  "payload": "{doc_uuid}"
+}]
+```
+
+## DELETE /documents/{doc_type_endpoint}/{doc_uuid}
+
+Delete document.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.uuid: {doc_uuid}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the document deletion.
+
+===
+
+```json
+[{
+  "event": "document:delete",
+  "payload": {
+    "uuid": "{doc_uuid}",
+    "type": "{doc_type}"
+  }
+},
+{
+  "event": "document:{doc_type}:delete",
+  "payload": "{doc_uuid}"
+}]
+```
+
+## PATCH /types/{doc_type}
+
+Update document type.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Test document type - Updated"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "Document type updated"
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the document type update.
+
+===
+
+```json
+[{
+  "event": "document_type:update",
+  "payload": "{doc_type}"
+}]
+```
+
+## DELETE /types/{doc_type}
+
+Delete document type.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the document type deletion.
+
+===
+
+```json
+[{
+  "event": "document_type:delete",
+  "payload": "{doc_type}"
+}]
+```
+
+## POST /files
+
+Create a file.
+
+Note: the data is "File content" encoded in base64.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "filename":"webhook-file.txt",
+  "mimetype":"text/plain",
+  "data": "RmlsZSBjb250ZW50Cg=="
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "File created"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // UUID {file_uuid}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the file creation.
+
+===
+
+```json
+[{
+  "event": "file:create",
+  "payload": "{file_uuid}"
+}]
+```
+
+## PATCH /files/{file_uuid}
+
+Update file.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "filename":"webhook-file-updated.txt"
+}
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "File updated"
+* Data.uuid: {file_uuid}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the file update.
+
+===
+
+```json
+[{
+  "event": "file:update",
+  "payload": "{file_uuid}"
+}]
+```
+
+## POST /files/{file_uuid}/content
+
+Update file content.
+
+* Content-Type: "text/plain"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```txt
+File content - updated
+
+```
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "File content created"
+* Data.uuid: {file_uuid}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the file update.
+
+===
+
+```json
+[{
+  "event": "file:update",
+  "payload": "{file_uuid}"
+}]
+```
+
+## DELETE /files/{file_uuid}
+
+Delete file.
+
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.message: "File deleted"
+* Data.uuid: {file_uuid}
+
+## GET /wait
+
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+
+## GET {WEBHOOK_SERVER_URL}
+
+Check if we received the notification for the file deletion.
+
+===
+
+```json
+[{
+  "event": "file:delete",
+  "payload": "{file_uuid}"
+}]
+```

--- a/tests/webhooks/index.php
+++ b/tests/webhooks/index.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Test webhooks.
+ */
+
+/**
+ * Store data in the shared memory.
+ */
+function save_data($data) {
+  // Only keep the last 10 request payload.
+  $data = array_merge([$data], load_data());
+  $data = implode('|', array_slice($data, 0, 10));
+
+  $shm_key = ftok(__FILE__, 't');
+  $shm_id = shmop_open($shm_key, 'c', 0644, 10000);
+
+  if (!empty($shm_id)) {
+    shmop_write($shm_id, strlen($data) . ':' . $data, 0);
+    shmop_close($shm_id);
+  }
+}
+
+/**
+ * Load data from the shared memory.
+ */
+function load_data() {
+  $shm_key = ftok(__FILE__, 't');
+  $shm_id = shmop_open($shm_key, 'a', 0644, 10000);
+  if (!empty($shm_id)) {
+    $data = shmop_read($shm_id, 0, 0);
+    shmop_close($shm_id);
+  }
+  if (!empty($data)) {
+    list($length, $data) = explode(':', $data, 2);
+    return explode('|', substr($data, 0, (int) $length));
+  }
+  return [];
+}
+
+// Simple request handler: store the received data on POST, load it on GET.
+http_response_code(200);
+switch ($_SERVER['REQUEST_METHOD']) {
+  case 'POST':
+    save_data(file_get_contents('php://input'));
+    break;
+
+  case 'GET':
+    header('Content-Type: application/json');
+    print json_encode(array_map('json_decode', load_data()), JSON_PRETTY_PRINT) . PHP_EOL;
+    break;
+}


### PR DESCRIPTION
Ticket: DOC-59

This consolidates the webhook events and allow to subscribe to notifications for CUD operations on all document types/vocabularies or specific ones. It also adds notifications for files.

## Data

The notifications only contain the resource id/uuid and eventually resource type depending on the event and it's the responsibility of the subscriber to retrieve the full data afterwards.

This is to avoid issues with private content. For example if provider A listens to events on the doc type `truc` and provider B creates a private `truc` document then, the provider A shouldn't not receive data that it would not have access to normally which could happen if we were to pass the entire resource data to the webhooks.

An alternative but more expensive option, could be to load all the registered webhooks, get their provider, and generate different data for each provider.

## Events

- document_type:create
- document_type:update
- document_type:delete
- vocabulary:create
- vocabulary:update
- vocabulary:delete
- field:document_type:create
- field:document_type:update
- field:document_type:delete
- field:vocabulary:create
- field:vocabulary:update
- field:vocabulary:delete
- document:create
- document:update
- document:delete
- document:{doc_type}:create
- document:{doc_type}:update
- document:{doc_type}:delete
- term:create
- term:update
- term:delete
- term:{vocabulary}:create
- term:{vocabulary}:update
- term:{vocabulary}:delete
- file:create
- file:update
- file:delete

**TODO**: bulk endpoints, revision publication, file revision deletion

## Tests

I added tests for all the above events. There is a tiny php (see `tests/webhooks/index.php`) server running that queues the notifications and output them when receiving GET requests.

I updated the version of `silk` to be able to request other URLs than the base one passed via the `silk.url` parameter, inside a script (see `tests/silk_webhooks.md`)