### PR TITLE
Add operation to local group title

### DIFF
--- a/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
+++ b/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
@@ -151,9 +151,11 @@ function docstore_local_coordination_groups_sync($url = '') {
           }
         }
       }
+      $label = $row->label . " - " . reset($row->operation)->label;
+
       if (empty($term)) {
         $item = [
-          'name' => $row->label,
+          'name' => $label,
           'vid' => $vocabulary->id(),
           'created' => [],
           'provider_uuid' => [],
@@ -177,6 +179,12 @@ function docstore_local_coordination_groups_sync($url = '') {
         ];
 
         $term = Term::create($item);
+      }
+
+      // Needed once to update all terms.
+      $check = \Drupal::state()->get('docstore_sync_local_groups_name_update', '');
+      if (empty($check)) {
+        $term->set('name', $label);
       }
 
       foreach ($fields as $name => $type) {
@@ -265,3 +273,4 @@ function docstore_local_coordination_groups_sync($url = '') {
 // Auto execute.
 docstore_local_coordination_groups_sync();
 \Drupal::service('docstore.vocabulary_controller')->rebuildAccessibleResourceTypes('taxonomy_vocabulary');
+\Drupal::state()->set('docstore_sync_local_groups_name_update', 'processed');

--- a/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
+++ b/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
@@ -28,6 +28,7 @@ function docstore_local_coordination_groups_fields() {
       'id' => 'string',
       'email' => 'string',
       'website' => 'string',
+      'display_label' => 'string',
       'global_cluster' => [
         'type' => 'term_reference',
         'target' => 'global_coordination_groups',
@@ -151,11 +152,16 @@ function docstore_local_coordination_groups_sync($url = '') {
           }
         }
       }
-      $label = $row->label . " - " . reset($row->operation)->label;
+
+      $display_label = $row->label;
+      if (isset($row->operation) && isset($row->operation[0])) {
+        $display_label .= " - " . reset($row->operation)->label;
+      }
 
       if (empty($term)) {
         $item = [
-          'name' => $label,
+          'name' => $row->label,
+          'display_label' => $display_label,
           'vid' => $vocabulary->id(),
           'created' => [],
           'provider_uuid' => [],
@@ -184,7 +190,7 @@ function docstore_local_coordination_groups_sync($url = '') {
       // Needed once to update all terms.
       $check = \Drupal::state()->get('docstore_sync_local_groups_name_update', '');
       if (empty($check)) {
-        $term->set('name', $label);
+        $term->set('display_label', $display_label);
       }
 
       foreach ($fields as $name => $type) {
@@ -265,7 +271,7 @@ function docstore_local_coordination_groups_sync($url = '') {
 
   // Check for more data.
   if (isset($data->next) && isset($data->next->href)) {
-    print "\nNext up:\n" . $data->next->href;
+    print "\nNext up: $data->next->href \n";
     docstore_local_coordination_groups_sync($data->next->href);
   }
 }


### PR DESCRIPTION
This is primarily for the Local coordination groups field on https://assessments.hpc.tools/assessment/add - I looked at altering just the options, but as this field is useless without the context of its operation, I think it's worth having in the title in the docstore.

Not sure whether it should be `<local group> - <operation>` or `<local group> [<operation>]`, but I think either is okay.