### PR TITLE
revert tiny cleanup that stops script running

### DIFF
--- a/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
+++ b/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
@@ -271,7 +271,7 @@ function docstore_local_coordination_groups_sync($url = '') {
 
   // Check for more data.
   if (isset($data->next) && isset($data->next->href)) {
-    print "\nNext up: $data->next->href \n";
+    print "\nNext up:\n" . $data->next->href . "\n";
     docstore_local_coordination_groups_sync($data->next->href);
   }
 }


### PR DESCRIPTION
Added a last minute 'tidy' that interrupts the script: https://jenkins.aws.ahconu.org/view/Docstore/job/docstore-dev-drush/87/console Reverting.