### PR TITLE
adjust print statement to understand error on jenkins only

### DIFF
--- a/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
+++ b/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
@@ -271,7 +271,7 @@ function docstore_local_coordination_groups_sync($url = '') {
 
   // Check for more data.
   if (isset($data->next) && isset($data->next->href)) {
-    print "\nNext up:\n" . $data->next->href . "\n";
+    print serialize($data->next->href);
     docstore_local_coordination_groups_sync($data->next->href);
   }
 }


### PR DESCRIPTION
Got an error on jenkins run that I can't reproduce locally. This tiny change might let me understand it better.

(The suggestion on https://jenkins.aws.ahconu.org/view/Docstore/job/docstore-dev-drush/88/console to use --no-halt-on-error wasn't useful: https://jenkins.aws.ahconu.org/view/Docstore/job/docstore-dev-drush/89/console)