### PR TITLE
[AR-224] index display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The document store supports multiple document types ("Content types"), these can
 
 ## Document fields ([Docs](https://un-ocha.github.io/doc-store-api/#/Document/post-document-fields))
 
-To add new fields to a document type, you can use the `api/fields/{type}` endpoint.
+To add new fields to a document type, you can use the `api/{type}/fields` endpoint.
 
 | field | default | required | info |
 | -----  | -------- | -------- | ---- |
@@ -158,7 +158,7 @@ Example
 
 ### Multi property values
 
-Date range have an end date, so needs special treatment.
+Date range has an end date, so needs special treatment.
 
 ```json
   {

--- a/html/modules/custom/docstore/src/Commands/DocstoreCommands.php
+++ b/html/modules/custom/docstore/src/Commands/DocstoreCommands.php
@@ -257,7 +257,7 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
   }
 
   /**
-   * Reset the docstore for testing.
+   * Create test node type.
    *
    * @param string $id
    *   Node type id.
@@ -334,6 +334,14 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
       'prefix' => 'another_',
       'api_keys' => 'dcba',
       'api_keys_read_only' => 'yzzyx',
+    ]);
+
+    // Test provider 3.
+    // For creating vocabulary field through api without a prefix.
+    $this->createProvider(5, [
+      'name' => 'Prefix-less test',
+      'prefix' => '',
+      'api_keys' => 'zzzz',
     ]);
 
     $this->logger->success('Successfully created/resetted test users.');

--- a/html/modules/custom/docstore/src/ResourceTrait.php
+++ b/html/modules/custom/docstore/src/ResourceTrait.php
@@ -550,7 +550,10 @@ trait ResourceTrait {
       // the field name for the term label rather than "label" or if we were to
       // use "label" for all the entity types.
       if ($entity->getEntityTypeId() === 'taxonomy_term') {
-        $label_key = 'label';
+        // @todo This was included when there was a typo in 'taxonomy_term',
+        // but it causes tests to fail, so specifying 'name' for now.
+        // $label_key = 'label';
+        $label_key = 'name';
 
         // Add display label to local_coordination_groups.
         if ($entity->vid->first()->getValue()['target_id'] === 'local_coordination_groups') {

--- a/html/modules/custom/docstore/src/ResourceTrait.php
+++ b/html/modules/custom/docstore/src/ResourceTrait.php
@@ -557,7 +557,10 @@ trait ResourceTrait {
 
         // Add display label to local_coordination_groups.
         if ($entity->vid->first()->getValue()['target_id'] === 'local_coordination_groups') {
-          $item['display_label'] = $entity->display_label->first()->getValue()['value'];
+          $display_label = $entity->display_label ?? '';
+          if (isset($display_label[0])) {
+            $item['display_label'] = $display_label->first()->getValue()['value'];
+          }
         }
       }
       else {

--- a/html/modules/custom/docstore/src/ResourceTrait.php
+++ b/html/modules/custom/docstore/src/ResourceTrait.php
@@ -571,8 +571,8 @@ trait ResourceTrait {
       }
 
       // Add display label if there is one.
-      if (isset($entity->display_label) && !$entity->display_label->isEmpty()) {
-        $item['display_label'] = $entity->display_label->first()->getValue()['value'];
+      if (!empty($entity->display_name) && !$entity->display_name->isEmpty()) {
+        $item['display_name'] = $entity->display_name->value;
       }
 
       $data[] = $item;

--- a/html/modules/custom/docstore/src/ResourceTrait.php
+++ b/html/modules/custom/docstore/src/ResourceTrait.php
@@ -550,18 +550,7 @@ trait ResourceTrait {
       // the field name for the term label rather than "label" or if we were to
       // use "label" for all the entity types.
       if ($entity->getEntityTypeId() === 'taxonomy_term') {
-        // @todo This was included when there was a typo in 'taxonomy_term',
-        // but it causes tests to fail, so specifying 'name' for now.
-        // $label_key = 'label';
-        $label_key = 'name';
-
-        // Add display label to local_coordination_groups.
-        if ($entity->vid->first()->getValue()['target_id'] === 'local_coordination_groups') {
-          $display_label = $entity->display_label ?? '';
-          if (isset($display_label[0])) {
-            $item['display_label'] = $display_label->first()->getValue()['value'];
-          }
-        }
+        $label_key = 'label';
       }
       else {
         $label_key = $this->entityTypeManager
@@ -579,6 +568,11 @@ trait ResourceTrait {
       if ($entity->getEntityTypeId() === 'node' && $expand_references) {
         $extra_data = $this->prepareEntityResourceData($entity, $provider, FALSE);
         $item = array_merge($item, $extra_data);
+      }
+
+      // Add display label if there is one.
+      if (isset($entity->display_label) && !$entity->display_label->isEmpty()) {
+        $item['display_label'] = $entity->display_label->first()->getValue()['value'];
       }
 
       $data[] = $item;

--- a/html/modules/custom/docstore/src/ResourceTrait.php
+++ b/html/modules/custom/docstore/src/ResourceTrait.php
@@ -549,8 +549,13 @@ trait ResourceTrait {
       // @todo It would much easier if we were to use "name" for terms which is
       // the field name for the term label rather than "label" or if we were to
       // use "label" for all the entity types.
-      if ($entity->getEntityTypeId() === 'taxonony_term') {
+      if ($entity->getEntityTypeId() === 'taxonomy_term') {
         $label_key = 'label';
+
+        // Add display label to local_coordination_groups.
+        if ($entity->vid->first()->getValue()['target_id'] === 'local_coordination_groups') {
+          $item['display_label'] = $entity->display_label->first()->getValue()['value'];
+        }
       }
       else {
         $label_key = $this->entityTypeManager

--- a/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
+++ b/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
@@ -28,7 +28,7 @@ function docstore_local_coordination_groups_fields() {
       'id' => 'string',
       'email' => 'string',
       'website' => 'string',
-      'display_label' => 'string',
+      'display_name' => 'string',
       'global_cluster' => [
         'type' => 'term_reference',
         'target' => 'global_coordination_groups',
@@ -153,15 +153,15 @@ function docstore_local_coordination_groups_sync($url = '') {
         }
       }
 
-      $display_label = $row->label;
+      $display_name = $row->label;
       if (isset($row->operation) && isset($row->operation[0])) {
-        $display_label .= " - " . reset($row->operation)->label;
+        $display_name .= " - " . reset($row->operation)->label;
       }
 
       if (empty($term)) {
         $item = [
           'name' => $row->label,
-          'display_label' => $display_label,
+          'display_name' => $display_name,
           'vid' => $vocabulary->id(),
           'created' => [],
           'provider_uuid' => [],
@@ -190,7 +190,7 @@ function docstore_local_coordination_groups_sync($url = '') {
       // Needed once to update all terms.
       $check = \Drupal::state()->get('docstore_sync_local_groups_name_update', '');
       if (empty($check)) {
-        $term->set('display_label', $display_label);
+        $term->set('display_name', $display_name);
       }
 
       foreach ($fields as $name => $type) {

--- a/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
+++ b/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php
@@ -211,6 +211,9 @@ function docstore_local_coordination_groups_sync($url = '') {
                 if (empty($lookup_item)) {
                   continue;
                 }
+                if ($lookup_item->label === 'République centrafricaine') {
+                  $lookup_item->label = 'Central African Republic';
+                }
 
                 $entities = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
                   'name' => $lookup_item->label,

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,7 +19,7 @@ get_media_uuid() {
 stop_webhook_server() {
   if [ "$DOCSTORE_PHP_WEBHOOK_SERVER_PID" != "" ]; then
     echo "Stopping webhook test server"
-    kill $DOCSTORE_PHP_WEBHOOK_SERVER_PID
+    kill "$DOCSTORE_PHP_WEBHOOK_SERVER_PID"
     DOCSTORE_PHP_WEBHOOK_SERVER_PID=
   fi
 }
@@ -30,33 +30,22 @@ trap stop_webhook_server 0
 # Reset docstore for testing.
 $DRUSH docstore:test-reset
 
-# Add document type.
-# @todo check if that's used in the tests and whether that should be replaced
-# by an API call where relevant.
-$DRUSH docstore:test-create-node-type document documents
-
-# Add countries vocabulary.
-# @todo it's only used for the sild_document_crud tests and only to
-# look up Aruba. Replace that with a command to create a vocabulary and a test
-# term instead as it's pretty slow.
-$DRUSH --verbose scr ../html/modules/custom/docstore/syncs/docstore_countries.php
-
 # Run base tests.
-$SILK -test.v -silk.url $API silk_vocabulary_crud.md || exit 1;
-$SILK -test.v -silk.url $API silk_vocabulary_bulk.md || exit 1;
-$SILK -test.v -silk.url $API silk_vocabulary_bulk_cud.md || exit 1;
-$SILK -test.v -silk.url $API silk_vocabulary_anon_cud.md || exit 1;
-$SILK -test.v -silk.url $API silk_vocabulary_anon_r.md || exit 1;
-$SILK -test.v -silk.url $API silk_document_types_crud.md || exit 1;
-$SILK -test.v -silk.url $API silk_document_crud.md || exit 1;
-$SILK -test.v -silk.url $API silk_document_bulk.md || exit 1;
-$SILK -test.v -silk.url $API silk_document_bulk_cud.md || exit 1;
-$SILK -test.v -silk.url $API silk_geofield.md || exit 1;
-$SILK -test.v -silk.url $API silk_linkfield.md || exit 1;
-$SILK -test.v -silk.url $API silk_child_terms.md || exit 1;
-$SILK -test.v -silk.url $API silk_private.md || exit 1;
-$SILK -test.v -silk.url $API silk_document_revisions.md || exit 1;
-$SILK -test.v -silk.url $API silk_term_revisions.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_vocabulary_crud.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_vocabulary_bulk.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_vocabulary_bulk_cud.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_vocabulary_anon_cud.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_vocabulary_anon_r.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_document_types_crud.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_document_crud.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_document_bulk.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_document_bulk_cud.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_geofield.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_linkfield.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_child_terms.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_private.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_document_revisions.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_term_revisions.md || exit 1;
 
 # Reset docstore for testing.
 $DRUSH docstore:test-reset
@@ -68,7 +57,7 @@ sleep 2
 export WEBHOOK_SERVER_URL=http://localhost:8765
 
 # Test webhooks.
-$SILK -test.v -silk.url $API silk_webhooks.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_webhooks.md || exit 1;
 
 # Stop webhook server
 stop_webhook_server
@@ -77,31 +66,33 @@ stop_webhook_server
 $DRUSH docstore:test-reset
 
 # Test the document files endpoint.
-$SILK -test.v -silk.url $API silk_document_files.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_document_files.md || exit 1;
 
 # Reset docstore for testing.
 $DRUSH docstore:test-reset
-
-# Add document type
-$DRUSH docstore:test-create-node-type document documents
 
 # Prepare for file related tests.
-export FILE_PRIVATE=$(base64 ./files/private.pdf | tr -d '\n')
+FILE_PRIVATE=$(base64 ./files/private.pdf | tr -d '\n')
+export FILE_PRIVATE
 
 # Run file tests.
-$SILK -test.v -silk.url $API silk_files.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_files.md || exit 1;
 
 # Run tests that depends on the files.
-$SILK -test.v -silk.url $API silk_create.md || exit 1;
-$SILK -test.v -silk.url $API silk_exceptions.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_create.md || exit 1;
+$SILK -test.v -silk.url "$API" silk_exceptions.md || exit 1;
 
 # Reset docstore for testing.
 $DRUSH docstore:test-reset
 
-export PROVIDER_UUID1="$(curl -s -H "API-KEY: abcd" $API/me | get_uuid)"
-export PROVIDER_UUID2="$(curl -s -H "API-KEY: dcba" $API/me | get_uuid)"
-export PROVIDER_TOKEN1=$(php -r "print md5('abcd' . '$PROVIDER_UUID1');")
-export PROVIDER_TOKEN2=$(php -r "print md5('dbca' . '$PROVIDER_UUID2');")
+PROVIDER_UUID1="$(curl -s -H "API-KEY: abcd" "$API/me" | get_uuid)"
+export PROVIDER_UUID1
+PROVIDER_UUID2="$(curl -s -H "API-KEY: dcba" "$API/me" | get_uuid)"
+export PROVIDER_UUID2
+PROVIDER_TOKEN1=$(php -r "print md5('abcd' . '$PROVIDER_UUID1');")
+export PROVIDER_TOKEN1
+PROVIDER_TOKEN2=$(php -r "print md5('dbca' . '$PROVIDER_UUID2');")
+export PROVIDER_TOKEN2
 
 # Run direct download tests.
-$SILK -test.v -silk.url $HOST silk_files_direct.md || exit 1;
+$SILK -test.v -silk.url "$HOST" silk_files_direct.md || exit 1;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -85,14 +85,5 @@ $SILK -test.v -silk.url "$API" silk_exceptions.md || exit 1;
 # Reset docstore for testing.
 $DRUSH docstore:test-reset
 
-PROVIDER_UUID1="$(curl -s -H "API-KEY: abcd" "$API/me" | get_uuid)"
-export PROVIDER_UUID1
-PROVIDER_UUID2="$(curl -s -H "API-KEY: dcba" "$API/me" | get_uuid)"
-export PROVIDER_UUID2
-PROVIDER_TOKEN1=$(php -r "print md5('abcd' . '$PROVIDER_UUID1');")
-export PROVIDER_TOKEN1
-PROVIDER_TOKEN2=$(php -r "print md5('dbca' . '$PROVIDER_UUID2');")
-export PROVIDER_TOKEN2
-
 # Run direct download tests.
 $SILK -test.v -silk.url "$HOST" silk_files_direct.md || exit 1;

--- a/tests/silk_create.md
+++ b/tests/silk_create.md
@@ -604,9 +604,34 @@ Example output.
 * Data.description: "Term updated"
 * Data.vocabulary: {organization}
 
+
+## POST /types
+
+Create a document type.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "machine_name": "test_doc",
+  "endpoint": "test-document",
+  "label": "Document",
+  "author": "common"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.machine_name: /.+/ // Endpoint {doc_type_machine_name}
+* Data.endpoint: /.+/ // Endpoint {doc_type_endpoint}
+
 # Add fields to documents
 
-## POST /types/document/fields
+## POST /types/{doc_type_machine_name}/fields
 
 Add city field.
 
@@ -637,7 +662,7 @@ Example output.
 * Data.message: "Field created"
 * Data.field_name: /^[0-9a-z_]+$/ // Machine_name {field_city}
 
-## POST /types/document/fields
+## POST /types/{doc_type_machine_name}/fields
 
 Add organizations field.
 
@@ -669,7 +694,7 @@ Example output.
 * Data.message: "Field created"
 * Data.field_name: /^[0-9a-z_]+$/ // Machine_name {field_organization}
 
-## POST /types/document/fields
+## POST /types/{doc_type_machine_name}/fields
 
 Add id field.
 
@@ -700,7 +725,7 @@ Example output.
 * Data.message: "Field created"
 * Data.field_name: /^[0-9a-z_]+$/ // Machine_name {field_id}
 
-## POST /documents/documents
+## POST /documents/{doc_type_endpoint}
 
 Add a document without a file.
 
@@ -753,7 +778,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## POST /documents/documents
+## POST /documents/{doc_type_endpoint}
 
 Add a document using term labels.
 
@@ -808,7 +833,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/documents
+## GET /documents/{doc_type_endpoint}
 
 * Accept: "application/json"
 * API-KEY: abcd
@@ -835,7 +860,7 @@ Example output.
 * Content-Type: "application/json"
 * Data[0].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {file1}
 
-## POST /documents/documents
+## POST /documents/{doc_type_endpoint}
 
 Add a document with a file.
 
@@ -890,7 +915,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/documents/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get document as owner.
 
@@ -907,7 +932,7 @@ Get document as owner.
 * Data.files[0].private: true
 * Data.files[0].uri: /.+/
 
-## GET /documents/documents/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get document as anonymous
 
@@ -923,7 +948,7 @@ Get document as anonymous
 * Data.files[0].private: true
 * Data.files[0].uri: null
 
-## GET /documents/documents/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get document as other user
 
@@ -940,7 +965,7 @@ Get document as other user
 * Data.files[0].private: true
 * Data.files[0].uri: null
 
-## POST /documents/documents
+## POST /documents/{doc_type_endpoint}
 
 Add an unpublished document.
 
@@ -990,7 +1015,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## POST /documents/documents
+## POST /documents/{doc_type_endpoint}
 
 Add a private document.
 
@@ -1040,7 +1065,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/documents/{doc4}
+## GET /documents/{doc_type_endpoint}/{doc4}
 
 Get unpublished document as owner.
 
@@ -1054,7 +1079,7 @@ Get unpublished document as owner.
 * Data.uuid: {doc4}
 * Data.published: false
 
-## GET /documents/documents/{doc5}
+## GET /documents/{doc_type_endpoint}/{doc5}
 
 Get private document as owner.
 
@@ -1068,7 +1093,7 @@ Get private document as owner.
 * Data.uuid: {doc5}
 * Data.private: true
 
-## GET /documents/documents/{doc4}
+## GET /documents/{doc_type_endpoint}/{doc4}
 
 Get unpublished document as anonymous.
 
@@ -1080,7 +1105,7 @@ Get unpublished document as anonymous.
 * Content-Type: "application/json"
 * Data.message: "Document {doc4} does not exist"
 
-## GET /documents/documents/{doc5}
+## GET /documents/{doc_type_endpoint}/{doc5}
 
 Get private document as anonymous.
 
@@ -1092,7 +1117,7 @@ Get private document as anonymous.
 * Content-Type: "application/json"
 * Data.message: "Document {doc5} does not exist"
 
-## GET /documents/documents/{doc4}
+## GET /documents/{doc_type_endpoint}/{doc4}
 
 Get unpublished document as other provider.
 
@@ -1105,7 +1130,7 @@ Get unpublished document as other provider.
 * Content-Type: "application/json"
 * Data.message: "Document {doc4} does not exist"
 
-## GET /documents/documents/{doc5}
+## GET /documents/{doc_type_endpoint}/{doc5}
 
 Get private document as other provider.
 
@@ -1140,7 +1165,7 @@ Example output.
 * Content-Type: "application/json"
 * Data.message: "Term is in use and can not be deleted"
 
-## GET /documents/documents
+## GET /documents/{doc_type_endpoint}
 
 Test filters.
 
@@ -1156,7 +1181,7 @@ Test filters.
 * Content-Type: "application/json"
 * Data.results[1].uuid: {doc1}
 
-## GET /documents/documents
+## GET /documents/{doc_type_endpoint}
 
 Test sort.
 
@@ -1170,7 +1195,7 @@ Test sort.
 * Content-Type: "application/json"
 * Data.results[0].uuid: {doc5}
 
-## GET /documents/documents
+## GET /documents/{doc_type_endpoint}
 
 Test sort as anonymous.
 
@@ -1183,7 +1208,7 @@ Test sort as anonymous.
 * Content-Type: "application/json"
 * Data.results[0].uuid: {doc3}
 
-## GET /documents/documents
+## GET /documents/{doc_type_endpoint}
 
 Test limit.
 
@@ -1197,7 +1222,7 @@ Test limit.
 * Content-Type: "application/json"
 * Data.results[0].uuid: {doc5}
 
-## GET /documents/documents
+## GET /documents/{doc_type_endpoint}
 
 Test offset.
 
@@ -1216,7 +1241,7 @@ Test offset.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/documents
+## GET /documents/{doc_type_endpoint}
 
 Test offset as anonymous.
 
@@ -1234,7 +1259,7 @@ Test offset as anonymous.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/documents
+## GET /documents/{doc_type_endpoint}
 
 Test illegal sort.
 
@@ -1248,7 +1273,7 @@ Test illegal sort.
 * Content-Type: "application/json"
 * Data.message: "Sort \"createdxx\" is not valid solr field."
 
-## GET /documents/documents
+## GET /documents/{doc_type_endpoint}
 
 Test full text search.
 

--- a/tests/silk_document_bulk_cud.md
+++ b/tests/silk_document_bulk_cud.md
@@ -144,6 +144,16 @@ Expected output.
 * Data[2].error.status: 404
 * Data[2].error.message: "Document does not exist"
 
+## GET /wait
+
+* Accept: "application/json"
+* API-KEY: abcd
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+
 ## GET /documents/test-document-bulk-cud/{doc_uuid1}
 
 Check the `title` and `field_id` of the first document have been updated.

--- a/tests/silk_document_crud.md
+++ b/tests/silk_document_crud.md
@@ -492,7 +492,7 @@ Get private document as owner.
 * Status: `200`
 * Content-Type: "application/json"
 * Data.uuid: {doc2}
-* Data.silk_country.name: "Aruba"
+* Data.silk_country.label: "Aruba"
 
 ## GET /documents/test-document-crud/{doc2}
 

--- a/tests/silk_document_crud.md
+++ b/tests/silk_document_crud.md
@@ -21,8 +21,10 @@ Create document type.
 
 * Status: `201`
 * Content-Type: "application/json"
+* Data.machine_name: /.+/ // Endpoint {doc_type_machine_name}
+* Data.endpoint: /.+/ // Endpoint {doc_type_endpoint}
 
-## POST /types/test_doc_crud/fields
+## POST /types/{doc_type_machine_name}/fields
 
 Test empty post.
 
@@ -39,7 +41,7 @@ Test empty post.
 * Content-Type: "application/json"
 * Data.message: "You have to pass a JSON object"
 
-## POST /types/test_doc_crud/fields
+## POST /types/{doc_type_machine_name}/fields
 
 Test empty post.
 
@@ -53,7 +55,7 @@ Test empty post.
 * Content-Type: "application/json"
 * Data.message: "You have to pass a JSON object"
 
-## POST /types/test_doc_crud/fields
+## POST /types/{doc_type_machine_name}/fields
 
 Test empty post.
 
@@ -71,7 +73,7 @@ Test empty post.
 * Content-Type: "application/json"
 * Data.message: "You have to pass a JSON object"
 
-## POST /types/test_doc_crud/fields
+## POST /types/{doc_type_machine_name}/fields
 
 Test illegal json post.
 
@@ -89,7 +91,7 @@ Test illegal json post.
 * Content-Type: "application/json"
 * Data.message: "You have to pass a JSON object"
 
-## POST /types/test_doc_crud/fields
+## POST /types/{doc_type_machine_name}/fields
 
 Add id field.
 
@@ -120,9 +122,9 @@ Example output.
 * Data.message: "Field created"
 * Data.field_name: /^[0-9a-z_]+$/ // Machine_name {field_id}
 
-## POST /types/test_doc_crud/fields
+## POST /vocabularies
 
-Add country field.
+Add test_vocab.
 
 * Content-Type: "application/json"
 * Accept: "application/json"
@@ -130,10 +132,40 @@ Add country field.
 
 ```json
 {
-  "label": "Country",
+  "machine_name": "test_vocab",
+  "label": "Test Vocab",
+  "author": "hid_123456789"
+}
+```
+
+===
+
+Example output.
+
+```json
+{
+  "message": "Vocabulary created"
+}
+```
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Vocabulary created"
+* Data.machine_name: /^[0-9a-z_]+$/ // Machine_name {test_vocab}
+
+## POST /vocabularies/{test_vocab}/fields
+
+Add display name field.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: zzzz
+
+```json
+{
+  "label": "Display Name",
   "author": "hid_123456789",
-  "type": "entity_reference_uuid",
-  "target": "countries"
+  "type": "string"
 }
 ```
 
@@ -150,9 +182,75 @@ Example output.
 * Status: `201`
 * Content-Type: "application/json"
 * Data.message: "Field created"
-* Data.field_name: /^[0-9a-z_]+$/ // Machine_name {field_country}
+* Data.field_name: /^[0-9a-z_]+$/ // Machine_name {display_name_field}
 
-## POST /documents/test-document-crud
+## POST /vocabularies/{test_vocab}/terms
+
+Add test term.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Test term",
+  "author": "hid_123456789",
+  "{display_name_field}": "Display name for test term"
+}
+```
+
+===
+
+Example output.
+
+```json
+{
+  "message": "Term created"
+}
+```
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Term created"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {test_term_uuid}
+* Data.display_name: /^[A-Za-z ]+$/ // Machine_name {display_name_value}
+
+
+
+## POST /types/{doc_type_machine_name}/fields
+
+Add term reference field.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Term reference",
+  "author": "hid_123456789",
+  "type": "entity_reference_uuid",
+  "target": "{test_vocab}"
+}
+```
+
+===
+
+Example output.
+
+```json
+{
+  "message": "Field created"
+}
+```
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "Field created"
+* Data.field_name: /^[0-9a-z_]+$/ // Machine_name {field_term_reference}
+
+## POST /documents/{doc_type_endpoint}
 
 Add a document as anonymous.
 
@@ -171,7 +269,7 @@ Add a document as anonymous.
 * Status: `403`
 * Content-Type: "application/json"
 
-## POST /documents/test-document-crud
+## POST /documents/{doc_type_endpoint}
 
 Add a document without title.
 
@@ -191,7 +289,7 @@ Add a document without title.
 * Content-Type: "application/json"
 * Data.message: "Title is required"
 
-## POST /documents/test-document-crud
+## POST /documents/{doc_type_endpoint}
 
 Add a document without author.
 
@@ -211,7 +309,7 @@ Add a document without author.
 * Content-Type: "application/json"
 * Data.message: "Author is required"
 
-## POST /documents/test-document-crud
+## POST /documents/{doc_type_endpoint}
 
 Add a minimal document.
 
@@ -252,7 +350,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud
+## GET /documents/{doc_type_endpoint}
 
 Test filters.
 
@@ -265,7 +363,7 @@ Test filters.
 * Content-Type: "application/json"
 * Data.results[0].uuid: {doc1}
 
-## GET /documents/test-document-crud
+## GET /documents/{doc_type_endpoint}
 
 Test filters.
 
@@ -279,7 +377,7 @@ Test filters.
 * Content-Type: "application/json"
 * Data.results[0].uuid: {doc1}
 
-## GET /documents/test-document-crud
+## GET /documents/{doc_type_endpoint}
 
 Test filters.
 
@@ -293,7 +391,7 @@ Test filters.
 * Content-Type: "application/json"
 * Data.results[0].uuid: {doc1}
 
-## GET /documents/test-document-crud
+## GET /documents/{doc_type_endpoint}
 
 Test filters.
 
@@ -313,7 +411,7 @@ Test filters.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud
+## GET /documents/{doc_type_endpoint}
 
 Test filters.
 
@@ -329,7 +427,7 @@ Test filters.
 * Content-Type: "application/json"
 * Data.results[0].uuid: {doc1}
 
-## GET /documents/test-document-crud
+## GET /documents/{doc_type_endpoint}
 
 Test filters.
 
@@ -352,7 +450,7 @@ Test filters.
 * Status: `200`
 * Content-Type: "application/json"
 
-## POST /documents/test-document-crud
+## POST /documents/{doc_type_endpoint}
 
 Add a private document.
 
@@ -366,7 +464,7 @@ Add a private document.
   "author": "hid_123456789",
   "private": true,
   "{field_id}": 42,
-  "{field_country}_label": "Aruba"
+  "{field_term_reference}_label": "Test term"
 }
 ```
 
@@ -395,7 +493,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## POST /documents/test-document-crud
+## POST /documents/{doc_type_endpoint}
 
 Add an unpublished document.
 
@@ -437,7 +535,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## POST /documents/test-document-crud
+## POST /documents/{doc_type_endpoint}
 
 Add an unpublished private document.
 
@@ -480,7 +578,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get private document as owner.
 
@@ -492,9 +590,9 @@ Get private document as owner.
 * Status: `200`
 * Content-Type: "application/json"
 * Data.uuid: {doc2}
-* Data.silk_country.label: "Aruba"
+* Data.silk_term_reference.display_name: {display_name_value}
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get private document as anonymous.
 
@@ -505,7 +603,7 @@ Get private document as anonymous.
 * Status: `404`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get private document as other provider.
 
@@ -517,7 +615,7 @@ Get private document as other provider.
 * Status: `404`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get unpublished document as owner.
 
@@ -530,7 +628,7 @@ Get unpublished document as owner.
 * Content-Type: "application/json"
 * Data.uuid: {doc3}
 
-## GET /documents/test-document-crud/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get unpublished document as anonymous.
 
@@ -541,7 +639,7 @@ Get unpublished document as anonymous.
 * Status: `404`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get unpublished document as other provider.
 
@@ -553,7 +651,7 @@ Get unpublished document as other provider.
 * Status: `404`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc4}
+## GET /documents/{doc_type_endpoint}/{doc4}
 
 Get private unpublished document as owner.
 
@@ -566,7 +664,7 @@ Get private unpublished document as owner.
 * Content-Type: "application/json"
 * Data.uuid: {doc4}
 
-## GET /documents/test-document-crud/{doc4}
+## GET /documents/{doc_type_endpoint}/{doc4}
 
 Get unpublished document as anonymous.
 
@@ -577,7 +675,7 @@ Get unpublished document as anonymous.
 * Status: `404`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc4}
+## GET /documents/{doc_type_endpoint}/{doc4}
 
 Get unpublished document as other provider.
 
@@ -589,7 +687,7 @@ Get unpublished document as other provider.
 * Status: `404`
 * Content-Type: "application/json"
 
-## PUT /documents/test-document-crud/{doc1}
+## PUT /documents/{doc_type_endpoint}/{doc1}
 
 Update minimal document.
 
@@ -627,7 +725,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc1}
+## GET /documents/{doc_type_endpoint}/{doc1}
 
 Get minimal document.
 
@@ -648,7 +746,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## PUT /documents/test-document-crud/{doc1}
+## PUT /documents/{doc_type_endpoint}/{doc1}
 
 Update minimal document as anonymous.
 
@@ -666,7 +764,7 @@ Update minimal document as anonymous.
 * Status: `403`
 * Content-Type: "application/json"
 
-## PUT /documents/test-document-crud/{doc1}
+## PUT /documents/{doc_type_endpoint}/{doc1}
 
 Update minimal document as other provider.
 
@@ -684,7 +782,7 @@ Update minimal document as other provider.
 * Status: `403`
 * Content-Type: "application/json"
 
-## PATCH /documents/test-document-crud/{doc2}
+## PATCH /documents/{doc_type_endpoint}/{doc2}
 
 Update private document.
 
@@ -724,7 +822,7 @@ Example output.
 * Content-Type: "application/json"
 
 
-## GET /documents/test-document-crud
+## GET /documents/{doc_type_endpoint}
 
 Test filters.
 
@@ -738,7 +836,7 @@ Test filters.
 * Content-Type: "application/json"
 * Data.results[0].uuid: {doc2}
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get Private document.
 
@@ -759,7 +857,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## PATCH /documents/test-document-crud/{doc2}
+## PATCH /documents/{doc_type_endpoint}/{doc2}
 
 Update private document as anonymous.
 
@@ -777,7 +875,7 @@ Update private document as anonymous.
 * Status: `403`
 * Content-Type: "application/json"
 
-## PATCH /documents/test-document-crud/{doc2}
+## PATCH /documents/{doc_type_endpoint}/{doc2}
 
 Update private document as other provider.
 
@@ -795,7 +893,7 @@ Update private document as other provider.
 * Status: `403`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get private document as owner.
 
@@ -808,7 +906,7 @@ Get private document as owner.
 * Content-Type: "application/json"
 * Data.uuid: {doc2}
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get private document as anonymous.
 
@@ -819,7 +917,7 @@ Get private document as anonymous.
 * Status: `404`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get private document as other provider.
 
@@ -831,7 +929,7 @@ Get private document as other provider.
 * Status: `404`
 * Content-Type: "application/json"
 
-## PATCH /documents/test-document-crud/{doc2}
+## PATCH /documents/{doc_type_endpoint}/{doc2}
 
 Make private document public.
 
@@ -870,7 +968,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get Private document.
 
@@ -891,7 +989,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get private document as owner.
 
@@ -904,7 +1002,7 @@ Get private document as owner.
 * Content-Type: "application/json"
 * Data.uuid: {doc2}
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get private document as anonymous.
 
@@ -916,7 +1014,7 @@ Get private document as anonymous.
 * Content-Type: "application/json"
 * Data.uuid: {doc2}
 
-## GET /documents/test-document-crud/{doc2}
+## GET /documents/{doc_type_endpoint}/{doc2}
 
 Get private document as other provider.
 
@@ -929,7 +1027,7 @@ Get private document as other provider.
 * Content-Type: "application/json"
 * Data.uuid: {doc2}
 
-## PATCH /documents/test-document-crud/{doc3}
+## PATCH /documents/{doc_type_endpoint}/{doc3}
 
 Make unpublished document public.
 
@@ -968,7 +1066,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get unpublished document.
 
@@ -989,7 +1087,7 @@ Example output.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get unpublished document as owner.
 
@@ -1002,7 +1100,7 @@ Get unpublished document as owner.
 * Content-Type: "application/json"
 * Data.uuid: {doc3}
 
-## GET /documents/test-document-crud/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get unpublished document as anonymous.
 
@@ -1013,7 +1111,7 @@ Get unpublished document as anonymous.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get unpublished document as other provider.
 
@@ -1025,7 +1123,7 @@ Get unpublished document as other provider.
 * Status: `200`
 * Content-Type: "application/json"
 
-## DELETE /documents/test-document-crud/{doc3}
+## DELETE /documents/{doc_type_endpoint}/{doc3}
 
 Delete private document as anonymous.
 
@@ -1036,7 +1134,7 @@ Delete private document as anonymous.
 * Status: `403`
 * Content-Type: "application/json"
 
-## DELETE /documents/test-document-crud/{doc3}
+## DELETE /documents/{doc_type_endpoint}/{doc3}
 
 Delete private document as other provider.
 
@@ -1048,7 +1146,7 @@ Delete private document as other provider.
 * Status: `403`
 * Content-Type: "application/json"
 
-## DELETE /documents/test-document-crud/{doc3}
+## DELETE /documents/{doc_type_endpoint}/{doc3}
 
 Delete private document as owner.
 
@@ -1071,7 +1169,7 @@ Delete private document as owner.
 * Status: `200`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get deleted unpublished document as owner.
 
@@ -1083,7 +1181,7 @@ Get deleted unpublished document as owner.
 * Status: `404`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get deleted unpublished document as anonymous.
 
@@ -1094,7 +1192,7 @@ Get deleted unpublished document as anonymous.
 * Status: `404`
 * Content-Type: "application/json"
 
-## GET /documents/test-document-crud/{doc3}
+## GET /documents/{doc_type_endpoint}/{doc3}
 
 Get deleted unpublished document as other provider.
 
@@ -1106,7 +1204,7 @@ Get deleted unpublished document as other provider.
 * Status: `404`
 * Content-Type: "application/json"
 
-## POST /types/test_doc_crud/fields
+## POST /types/{doc_type_machine_name}/fields
 
 Add required field.
 
@@ -1138,7 +1236,7 @@ Example output.
 * Data.message: "Field created"
 * Data.field_name: /^[0-9a-z_]+$/ // Machine_name {field_needed}
 
-## POST /documents/test-document-crud
+## POST /documents/{doc_type_endpoint}
 
 Add a minimal document.
 
@@ -1168,7 +1266,7 @@ Example output.
 * Content-Type: "application/json"
 * Data.message: "Unable to save resource: This value should not be null. (silk_needed)"
 
-## POST /documents/test-document-crud
+## POST /documents/{doc_type_endpoint}
 
 Add a minimal document.
 
@@ -1198,7 +1296,7 @@ Example output.
 * Content-Type: "application/json"
 * Data.message: "Test document CRUD created"
 
-## POST /documents/test-document-crud
+## POST /documents/{doc_type_endpoint}
 
 Add a minimal document.
 

--- a/tests/silk_exceptions.md
+++ b/tests/silk_exceptions.md
@@ -1,6 +1,6 @@
 # Document exceptions
 
-## GET /documents/documents/12321321313
+## GET /documents/test-document/12321321313
 
 * Accept: "application/json"
 * API-KEY: abcd


### PR DESCRIPTION
Noting that there might be some changes with fixing the 'taxonomy' typo - at the moment it's using 'name' for taxonomy terms, which is wished for in the 'todo'.

Also, not sure if this is the right place to index the display name, or if we want to use 'display_name' as a standard and index those if they exist for other referenced entities.