### PR TITLE
Add endpoint to get all terms at once

### DIFF
--- a/html/modules/custom/docstore/docstore.routing.yml
+++ b/html/modules/custom/docstore/docstore.routing.yml
@@ -497,6 +497,18 @@ docstore_get_vocabulary_terms:
     _auth: ['docstore_auth']
     docstore_crud: 'R'
     docstore_access_level: 'B'
+docstore_get_vocabulary_terms_option_list:
+  path: '/api/v1/vocabularies/{id}/terms/options'
+  defaults:
+    _controller: 'docstore.term_controller:getTermsAsOptionList'
+    _title: 'Get vocabulary terms'
+  methods: [GET]
+  requirements:
+    _docstore_access_check: 'TRUE'
+  options:
+    _auth: ['docstore_auth']
+    docstore_crud: 'R'
+    docstore_access_level: 'B'
 docstore_create_term_in_vocabulary:
   path: '/api/v1/vocabularies/{id}/terms'
   defaults:

--- a/html/modules/custom/docstore/src/Controller/TermController.php
+++ b/html/modules/custom/docstore/src/Controller/TermController.php
@@ -134,6 +134,25 @@ class TermController extends ControllerBase {
   }
 
   /**
+   * Get terms as option list.
+   *
+   * @param string $id
+   *   Vocabulary id or uuid.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   Docstore API request.
+   *
+   * @return \Drupal\Core\Cache\CacheableJsonResponse
+   *   JSON response with the list of terms.
+   */
+  public function getTermsAsOptionList($id, Request $request) {
+    /** @var \Drupal\taxonomy\Entity\Vocabulary $vocabulary */
+    $vocabulary = $this->loadVocabulary($id);
+
+    // Get the terms.
+    return $this->searchResources($request, 'taxonomy_term__option_list', $vocabulary);
+  }
+
+  /**
    * Get term.
    *
    * @param string $id


### PR DESCRIPTION
For AR I need a quick way to get all terms from a vocabulary, doing a loadMultiple on external entities is way to slow (8-10 seconds), so the idea was to add a new endpoint to the docstore so I can fetch all terms (uuid, label and display_name) at once. With an empty cache it takes around 2-3 seconds, all next calls are "instant"

PS: Code is a bit messy

Code from AR can be found at https://github.com/UN-OCHA/assessmentregistry8-site/pull/244/commits/f9fb8e074ee4638c323fbeadb5f90b2d10001a02