### PR TITLE
[AR-249] Do not use Solr to get a single document

### DIFF
--- a/html/modules/custom/docstore/src/Controller/DocumentController.php
+++ b/html/modules/custom/docstore/src/Controller/DocumentController.php
@@ -228,7 +228,7 @@ class DocumentController extends ControllerBase {
 
     // Load the document.
     $document = $this->loadDocument($id);
-    
+
     // Add cache contexts and tags.
     $cache = $this->createResponseCache()
       ->addCacheTags(['documents'])
@@ -237,17 +237,18 @@ class DocumentController extends ControllerBase {
     if (isset($node_type)) {
       $cache->addCacheableDependency($node_type);
     }
-    
+
     // Check access to the document: either public and published or provider is
     // the owner.
     if (!empty($document->private->value) || !$document->isPublished()) {
       if (!$this->providerIsOwner($document, $provider, 'owner_id', FALSE)) {
-        throw new CacheableNotFoundHttpException($cache, strtr('@label does not exist', [
+        throw new CacheableNotFoundHttpException($cache, strtr('@label @id does not exist', [
           '@label' => $this->getResourceTypeLabel('node', FALSE),
+          '@id' => $id,
         ]));
       }
     }
-    
+
     // Prepare the response data.
     $data = $this->prepareEntityResourceDataForResponse($document, $provider);
 

--- a/html/modules/custom/docstore/src/Controller/DocumentController.php
+++ b/html/modules/custom/docstore/src/Controller/DocumentController.php
@@ -222,8 +222,25 @@ class DocumentController extends ControllerBase {
     // Load the node type if not a request against all types of documents.
     $node_type = $type !== 'any' ? $this->loadDocumentType($type) : NULL;
 
-    // Get the document's data.
-    return $this->searchResources($request, 'node', $node_type, $id);
+    // Get the provider.
+    $provider = $this->getProvider();
+
+    // Load the document.
+    $document = $this->loadDocument($id);
+
+    // Prepare the response data.
+    $data = $this->prepareEntityResourceDataForResponse($document, $provider);
+
+    // Add cache contexts and tags.
+    $cache = $this->createResponseCache()
+      ->addCacheTags(['documents'])
+      ->addCacheableDependency($document);
+
+    if (isset($node_type)) {
+      $cache->addCacheableDependency($node_type);
+    }
+
+    return $this->createCacheableJsonResponse($cache, $data, 200);
   }
 
   /**


### PR DESCRIPTION
Ticket: AR-249

Doing a SolR request just to get one document is overkill and may cause issues when the request is performed before SolR has finished indexing the content. So just get the data from the DB.

Note: we should do the same for the `DocumentController::getDocumentRevisions` and `DocumentController::getDocumentFiles` and `TermController::getTerm`.