### PR TITLE
[AR-240] remove redundant vocabulary load - which did not work

### DIFF
--- a/html/modules/custom/docstore/src/Commands/DocstoreCommands.php
+++ b/html/modules/custom/docstore/src/Commands/DocstoreCommands.php
@@ -261,7 +261,6 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
       }
 
       foreach (array_keys($fields) as $name) {
-
         $field_name = str_replace('-', '_', $name);
 
         // Handle special cases.

--- a/html/modules/custom/docstore/src/Commands/DocstoreCommands.php
+++ b/html/modules/custom/docstore/src/Commands/DocstoreCommands.php
@@ -176,10 +176,6 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
       }
     }
 
-    // Load vocabulary.
-    $vocabulary = $this->entityTypeManager->getStorage('taxonomy_term')
-      ->load('locations');
-
     // Get vocabulary fields.
     $fields = $this->entityFieldManager
       ->getFieldDefinitions('taxonomy_term', 'locations');
@@ -233,7 +229,7 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
         $item = [
           'name' => $row->label,
           'display_name' => $display_name,
-          'vid' => $vocabulary->id(),
+          'vid' => 'locations',
           'created' => [],
           'provider_uuid' => [],
           'parent' => [],
@@ -567,10 +563,6 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
 
     $url = 'https://api.reliefweb.int/v1/references/disaster-types?appname=vocabulary';
 
-    // Load vocabulary.
-    $vocabulary = $this->entityTypeManager
-      ->getStorage('taxonomy_term')->load('disaster_types');
-
     // Load provider.
     $provider = $this->entityTypeManager
       ->getStorage('user')->load(2);
@@ -587,7 +579,7 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
       if (!$terms) {
         $item = [
           'name' => $row->fields->name,
-          'vid' => $vocabulary->id(),
+          'vid' => 'disaster_types',
           'created' => [],
           'provider_uuid' => [],
           'parent' => [],
@@ -671,10 +663,6 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
 
     $url = 'https://vocabulary.unocha.org/json/beta-v3/countries.json';
 
-    // Load vocabulary.
-    $vocabulary = $this->entityTypeManager
-      ->getStorage('taxonomy_term')->load('countries');
-
     // Load provider.
     $provider = $this->entityTypeManager
       ->getStorage('user')->load(2);
@@ -689,7 +677,7 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
         if (!$term) {
           $item = [
             'name' => $row->label->default,
-            'vid' => $vocabulary->id(),
+            'vid' => 'countries',
             'created' => [],
             'provider_uuid' => [],
             'parent' => [],


### PR DESCRIPTION
Vocabulary load syntax was wrong, but didn't get discovered until scripts needed to create a new term.

This simplifies it.