### PR TITLE
[AR-240] populate both id fields

### DIFF
--- a/html/modules/custom/docstore/src/Commands/DocstoreCommands.php
+++ b/html/modules/custom/docstore/src/Commands/DocstoreCommands.php
@@ -265,6 +265,7 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
 
         // Handle special cases.
         if ($field_name == 'id') {
+          $term->set($field_name, $row->id);
           continue;
         }
         if ($field_name == 'hrinfo_id') {


### PR DESCRIPTION
Locations were getting imported multiple times as the id field wasn't getting populated. This fixes that.