### PR TITLE
[RW-45] Allow passing UUID

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "drupal/stage_file_proxy": "^1.0@RC",
         "drupal/user_bundle": "^1.0",
         "drupal/webhooks": "1.x-dev@dev",
-        "drush/drush": "^9.0.0"
+        "drush/drush": "^9.0.0",
+        "symfony/uid": "^5.3"
     },
     "require-dev": {
         "dmore/chrome-mink-driver": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "250e8f935609330197f60fbf1388a96b",
+    "content-hash": "0ad424a95ee51a42e7d0550621d9e29f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10364,6 +10364,85 @@
             "time": "2020-05-12T16:14:59+00:00"
         },
         {
+            "name": "symfony/polyfill-uuid",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-uuid.git",
+                "reference": "9165effa2eb8a31bb3fa608df9d529920d21ddd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/9165effa2eb8a31bb3fa608df9d529920d21ddd9",
+                "reference": "9165effa2eb8a31bb3fa608df9d529920d21ddd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-uuid": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Uuid\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for uuid functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
             "name": "symfony/process",
             "version": "v3.4.41",
             "source": {
@@ -10771,6 +10850,79 @@
                 }
             ],
             "time": "2020-05-30T18:58:05+00:00"
+        },
+        {
+            "name": "symfony/uid",
+            "version": "v5.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/uid.git",
+                "reference": "7f7703a1d5e106b3619d556e8313a575a47ac3fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/7f7703a1d5e106b3619d556e8313a575a47ac3fa",
+                "reference": "7f7703a1d5e106b3619d556e8313a575a47ac3fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-uuid": "^1.15"
+            },
+            "require-dev": {
+                "symfony/console": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Uid\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to generate and represent UIDs",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "UID",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/uid/tree/v5.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-17T12:52:32+00:00"
         },
         {
             "name": "symfony/validator",
@@ -13104,5 +13256,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/html/modules/custom/docstore/src/Controller/FileController.php
+++ b/html/modules/custom/docstore/src/Controller/FileController.php
@@ -241,9 +241,20 @@ class FileController extends ControllerBase {
     // Support private files.
     $private = !empty($params['private']);
 
+    // Get the UUID if provided and valid.
+    $uuid = NULL;
+    if (!empty($params['uuid'])) {
+      if ($this->validateEntityUuid('media', $params['uuid'])) {
+        $uuid = $params['uuid'];
+      }
+      else {
+        throw new BadRequestHttpException('File UUID invalid or already in use');
+      }
+    }
+
     // Create the file entity.
     /** @var \Drupal\file\Entity\File $file */
-    $file = $this->createFileEntity($params['filename'], $params['mimetype'], $private, $provider);
+    $file = $this->createFileEntity($params['filename'], $params['mimetype'], $private, $provider, $uuid);
 
     // Case 1: binary content provided in the request params.
     if (!empty($params['data'])) {
@@ -268,7 +279,7 @@ class FileController extends ControllerBase {
     }
 
     // Create the media entity.
-    $media = $this->createMediaEntity($file, $private, $provider);
+    $media = $this->createMediaEntity($file, $private, $provider, $uuid);
 
     // Save the media and generate the symlinks if possible.
     $this->saveMedia($media, $file, $provider);

--- a/html/modules/custom/docstore/src/Controller/TermController.php
+++ b/html/modules/custom/docstore/src/Controller/TermController.php
@@ -393,6 +393,16 @@ class TermController extends ControllerBase {
       'description' => $params['description'] ?? '',
     ];
 
+    // Set the UUID if provided and valid.
+    if (!empty($params['uuid'])) {
+      if ($this->validateEntityUuid('taxonomy_term', $params['uuid'])) {
+        $item['uuid'] = $params['uuid'];
+      }
+      else {
+        throw new BadRequestHttpException('Term UUID invalid or already in use');
+      }
+    }
+
     // Add support for hierarchical vocabularies.
     if (isset($params['parent'])) {
       if (is_array($params['parent'])) {

--- a/html/modules/custom/docstore/src/MetadataTrait.php
+++ b/html/modules/custom/docstore/src/MetadataTrait.php
@@ -48,6 +48,7 @@ trait MetadataTrait {
       'files',
       'vocabulary',
       'parent',
+      'uuid',
     ];
 
     // Get the list of available fields for the entity type.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -87,3 +87,9 @@ $DRUSH docstore:test-reset
 
 # Run direct download tests.
 $SILK -test.v -silk.url "$HOST" silk_files_direct.md || exit 1;
+
+# Reset docstore for testing.
+$DRUSH docstore:test-reset
+
+# Test providing a UUID when creating a resource.
+$SILK -test.v -silk.url "$API" silk_uuids.md || exit 1;

--- a/tests/silk_uuids.md
+++ b/tests/silk_uuids.md
@@ -1,0 +1,652 @@
+# Test creating content with provided UUID.
+
+## POST /types
+
+Create a document type.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "machine_name": "test_doc_uuid",
+  "endpoint": "test-document-uuid",
+  "label": "Test document uuid",
+  "author": "common"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.endpoint: /.+/ // Endpoint {doc_type}
+
+## POST /documents/{doc_type}
+
+Add document `doc_1`.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 1",
+  "author": "common"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {doc_uuid_1}
+
+## POST /documents/{doc_type}
+
+Add document `doc_2` providing an existing uuid.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 2",
+  "author": "common",
+  "uuid": "{doc_uuid_1}"
+}
+```
+
+===
+
+* Status: `400`
+* Content-Type: "application/json"
+* Data.message: "Document UUID invalid or already in use"
+
+## POST /documents/{doc_type}
+
+Add document `doc_3` providing a non existing uuid.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 3",
+  "author": "common",
+  "uuid": "a4a423f3-3db3-4f0e-a850-ce3aacb3e521"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: "a4a423f3-3db3-4f0e-a850-ce3aacb3e521"
+
+## POST /vocabularies
+
+Create a vocabulary.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "machine_name": "test_voc_uuid",
+  "label": "Test vocabulary uuid",
+  "author": "common"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.machine_name: /^[0-9a-z_]+$/ // Machine_name {voc_machine_name}
+
+## POST /vocabularies/{voc_machine_name}/terms
+
+Add term `term_1`.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Term 1",
+  "author": "common"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Term UUID {term_uuid_1}
+
+## POST /vocabularies/{voc_machine_name}/terms
+
+Add term `term_2` with an existing uuid.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Term 2",
+  "author": "common",
+  "uuid": "{term_uuid_1}"
+}
+```
+
+===
+
+* Status: `400`
+* Content-Type: "application/json"
+* Data.message: "Term UUID invalid or already in use"
+
+## POST /vocabularies/{voc_machine_name}/terms
+
+Add term `term_1`.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "label": "Term 3",
+  "author": "common",
+  "uuid": "be3766a1-a8b9-4bb0-8b0d-34ba9f6b8c0a"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: "be3766a1-a8b9-4bb0-8b0d-34ba9f6b8c0a"
+
+## POST /files
+
+Create a file `file_1` with content.
+
+Note: the data is "Public file 1" encoded in base64.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "private": false,
+  "filename":"doc-file-public-1.txt",
+  "mimetype":"text/plain",
+  "data": "UHVibGljIGZpbGUgMQo="
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "File created"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // UUID {file_uuid_1}
+
+## POST /files
+
+Create a file `file_2` with content with an existing uuid.
+
+Note: the data is "Public file 1" encoded in base64.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "private": false,
+  "filename":"doc-file-public-2.txt",
+  "mimetype":"text/plain",
+  "data": "UHVibGljIGZpbGUgMQo=",
+  "uuid": "{file_uuid_1}"
+}
+```
+
+===
+
+* Status: `400`
+* Content-Type: "application/json"
+* Data.message: "File UUID invalid or already in use"
+
+## POST /files
+
+Create a file `file_3` with content with a non existing uuid.
+
+Note: the data is "Public file 1" encoded in base64.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "private": false,
+  "filename":"doc-file-public-3.txt",
+  "mimetype":"text/plain",
+  "data": "UHVibGljIGZpbGUgMQo=",
+  "uuid": "54590be1-3baf-4ab3-92a1-47ccb80f4915"
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.message: "File created"
+* Data.uuid: "54590be1-3baf-4ab3-92a1-47ccb80f4915"
+
+## GET /files/{file_uuid_1}/content
+
+Get the content of the file `file_1`.
+
+* Accept: "text/plain"
+* API-KEY: abcd
+
+===
+
+```txt
+Public file 1
+
+```
+
+* Status: `200`
+
+## GET {HOST}/files/{file_uuid_1}/test.txt
+
+Get the content of the file `file_1`.
+
+* Accept: "text/plain"
+* API-KEY: abcd
+
+===
+
+```txt
+Public file 1
+
+```
+
+* Status: `200`
+
+## POST /documents/{doc_type}
+
+Add document `doc_4` referencing an existing file as uuid.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 4",
+  "author": "common",
+  "files": [
+    "{file_uuid_1}"
+  ]
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {doc_uuid_4}
+
+## GET /documents/{doc_type}/{doc_uuid_4}
+
+Check the list of files of the document `doc_4`
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.uuid: {doc_uuid_4}
+* Data.files[0].uuid: {file_uuid_1}
+* Data.files[0].uri: /.+\/files\/[0-9a-f-]{36}\/.+/
+
+## POST /documents/{doc_type}
+
+Add document `doc_5` referencing an existing file as object.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 5",
+  "author": "common",
+  "files": [
+    {
+      "uuid": "{file_uuid_1}"
+    }
+  ]
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {doc_uuid_5}
+
+## GET /documents/{doc_type}/{doc_uuid_5}
+
+Check the list of files of the document `doc_5`
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.uuid: {doc_uuid_5}
+* Data.files[0].uuid: {file_uuid_1}
+* Data.files[0].uri: /.+\/files\/[0-9a-f-]{36}\/.+/
+
+## POST /documents/{doc_type}
+
+Add document `doc_6` fetching a file.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 6",
+  "author": "common",
+  "files": [
+    {
+      "uri": "{HOST}/files/{file_uuid_1}/test-fetch-1.txt"
+    }
+  ]
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {doc_uuid_6}
+
+## GET /documents/{doc_type}/{doc_uuid_6}
+
+Check the list of files of the document `doc_6`
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.uuid: {doc_uuid_6}
+* Data.files[0].uri: /.+\/files\/[0-9a-f-]{36}\/test-fetch-1\.txt/
+* Data.files[0].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {file_fetch_uuid_1}
+
+## GET {HOST}/files/{file_fetch_uuid_1}/test-fetch-1.txt
+
+Get the content of the file `file_fetch_1`.
+
+* Accept: "text/plain"
+* API-KEY: abcd
+
+===
+
+```txt
+Public file 1
+
+```
+
+* Status: `200`
+
+## POST /documents/{doc_type}
+
+Add document `doc_7` fetching a file, specifying the file uuid.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 7",
+  "author": "common",
+  "files": [
+    {
+      "uri": "{HOST}/files/{file_uuid_1}/test-fetch-2.txt",
+      "uuid": "f5d5b9f7-37a3-4e5b-99d7-ee0e381f692d"
+    }
+  ]
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {doc_uuid_7}
+
+## GET /documents/{doc_type}/{doc_uuid_7}
+
+Check the list of files of the document `doc_7`
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.uuid: {doc_uuid_7}
+* Data.files[0].uri: /.+\/files\/f5d5b9f7-37a3-4e5b-99d7-ee0e381f692d\/test-fetch-2\.txt/
+* Data.files[0].uuid: "f5d5b9f7-37a3-4e5b-99d7-ee0e381f692d" // Machine_name {file_fetch_uuid_2}
+
+## GET {HOST}/files/{file_fetch_uuid_2}/test-fetch-2.txt
+
+Get the content of the file `file_fetch_2`.
+
+* Accept: "text/plain"
+* API-KEY: abcd
+
+===
+
+```txt
+Public file 1
+
+```
+
+* Status: `200`
+
+## POST /documents/{doc_type}
+
+Add document `doc_8` fetching a file, specifying an existing file uuid.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 8",
+  "author": "common",
+  "files": [
+    {
+      "uri": "{HOST}/files/{file_uuid_1}/test-fetch-3.txt",
+      "uuid": "{file_fetch_uuid_1}"
+    }
+  ]
+}
+```
+
+===
+
+* Status: `400`
+* Content-Type: "application/json"
+* Data.message: "File UUID invalid or already in use"
+
+## POST /documents/{doc_type}
+
+Add document `doc_9` getting a file from the dropfolder
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 9",
+  "author": "common",
+  "files": [
+    {
+      "filename": "test_file.txt"
+    }
+  ]
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {doc_uuid_9}
+
+## GET /documents/{doc_type}/{doc_uuid_9}
+
+Check the list of files of the document `doc_9`
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.uuid: {doc_uuid_9}
+* Data.files[0].uri: /.+\/files\/[0-9a-f-]{36}\/test_file\.txt/
+* Data.files[0].uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {file_dropfolder_uuid_1}
+
+## GET {HOST}/files/{file_dropfolder_uuid_1}/test_file.txt
+
+Get the content of the file `file_dropfolder_1`.
+
+* Accept: "text/plain"
+* API-KEY: abcd
+
+===
+
+```txt
+Test file for drop folder import
+
+```
+
+* Status: `200`
+
+## POST /documents/{doc_type}
+
+Add document `doc_10` fetching a file, specifying the file uuid.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 10",
+  "author": "common",
+  "files": [
+    {
+      "filename": "test_file.txt",
+      "uuid": "2d315f23-cb71-4381-8e72-6ddda2d7d234"
+    }
+  ]
+}
+```
+
+===
+
+* Status: `201`
+* Content-Type: "application/json"
+* Data.uuid: /^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/ // Machine_name {doc_uuid_10}
+
+## GET /documents/{doc_type}/{doc_uuid_10}
+
+Check the list of files of the document `doc_10`
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+
+===
+
+* Status: `200`
+* Content-Type: "application/json"
+* Data.uuid: {doc_uuid_10}
+* Data.files[0].uri: /.+\/files\/2d315f23-cb71-4381-8e72-6ddda2d7d234\/test_file\.txt/
+* Data.files[0].uuid: "2d315f23-cb71-4381-8e72-6ddda2d7d234" // Machine_name {file_dropfolder_uuid_2}
+
+## GET {HOST}/files/{file_dropfolder_uuid_2}/test_file.txt
+
+Get the content of the file `file_fetch_2`.
+
+* Accept: "text/plain"
+* API-KEY: abcd
+
+===
+
+```txt
+Test file for drop folder import
+
+```
+
+* Status: `200`
+
+## POST /documents/{doc_type}
+
+Add document `doc_11` fetching a file, specifying an existing file uuid.
+
+* Content-Type: "application/json"
+* Accept: "application/json"
+* API-KEY: abcd
+
+```json
+{
+  "title": "Doc 11",
+  "author": "common",
+  "files": [
+    {
+       "filename": "test_file.txt",
+      "uuid": "{file_fetch_uuid_1}"
+    }
+  ]
+}
+```
+
+===
+
+* Status: `400`
+* Content-Type: "application/json"
+* Data.message: "File UUID invalid or already in use"
+


### PR DESCRIPTION
Ticket: RW-45

This PR enables passing a UUID when creating a document, term or file. A check is performed to ensure the UUID is valid and not in use.

When creating a new file resource and passing a UUID, it used for the media entity. The associated file entity's uuid is derived from it.

This change allows an easy mapping between for RW nodes and files, for example, as using UUIDs v3 and the node/file URLs we have constant UUIDs. This would help a lot migrating the content to the docstore in a predictable and reproducible manner.