### PR TITLE
[AR-240] adjust author name

### DIFF
--- a/html/modules/custom/docstore/src/Commands/DocstoreCommands.php
+++ b/html/modules/custom/docstore/src/Commands/DocstoreCommands.php
@@ -615,7 +615,7 @@ class DocstoreCommands extends DrushCommands implements SiteAliasManagerAwareInt
         }
       }
 
-      $node->set('author', 'RW');
+      $node->set('author', 'Shared');
 
       $violations = $node->validate();
       if (count($violations) > 0) {


### PR DESCRIPTION
As per the comment in https://github.com/UN-OCHA/docstore-site/pull/168, changing the 'author' for disasters from 'RW' to 'Shared'.