### PR TITLE
[DOC-65] add patch for entity_reference_uuid module

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -6,6 +6,9 @@
         "drupal/config_ignore": {
             "https://www.drupal.org/project/config_ignore/issues/2857247": "https://www.drupal.org/files/issues/2021-01-04/config_ignore_2857247-61.patch"
         },
+        "drupal/entity_reference_uuid": {
+            "https://www.drupal.org/project/entity_reference_uuid/issues/3232098": "https://www.drupal.org/files/issues/2021-09-09/3232098-1.patch"
+        },
         "drupal/redis": {
             "https://www.drupal.org/project/redis/issues/3192255": "https://git.drupalcode.org/project/redis/-/merge_requests/3.diff"
         }


### PR DESCRIPTION
This addresses the failure in https://jenkins.aws.ahconu.org/job/docstore-dev-deploy/209/console - not sure how we (or anyone else) didn't hit it before.