### PR TITLE
[DOC-70] Bump user_bundle module version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4615,17 +4615,17 @@
         },
         {
             "name": "drupal/user_bundle",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/user_bundle.git",
-                "reference": "8.x-1.0"
+                "reference": "8.x-1.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/user_bundle-8.x-1.0.zip",
-                "reference": "8.x-1.0",
-                "shasum": "e311fa67e1b3a6077ec2dc6304a012fb05c850d3"
+                "url": "https://ftp.drupal.org/files/projects/user_bundle-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "ae2238f94b4e8702c330ffea3187caeb019f9a38"
             },
             "require": {
                 "drupal/core": "^8.7.7 || ^9"
@@ -4633,8 +4633,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.0",
-                    "datestamp": "1590590189",
+                    "version": "8.x-1.1",
+                    "datestamp": "1634943861",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Ticket: DOC-70

This bumps the version of user_bundle 1.1.0 so it's compatible with the current Drupal core version. That notably fixes an issue preventing the creation of a user via the UI.

## Tests

1. Checkout `develop` and to create a user via the UI (/admin/people  -> "add user"), you should get a PHP error
2. Checkout this branch (DOC-70), run composer install and check that it's now possible to create a user via the UI