### PR TITLE
fix: remove gulp commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,14 +149,6 @@
     },
     "scripts": {
         "git-hooks": "test -d .git && git config core.hooksPath git-hooks || exit 0",
-        "gulp-prepare": "test -f html/themes/custom/bootstrap_subtheme_sass/gulpfile.js && cd html/themes/custom/bootstrap_subtheme_sass && npm install || exit 0",
-        "gulp-build": "test -f html/themes/custom/bootstrap_subtheme_sass/gulpfile.js && cd html/themes/custom/bootstrap_subtheme_sass && ./node_modules/.bin/gulp build || exit 0",
-        "gulp-cleanup": "test -f html/themes/custom/bootstrap_subtheme_sass/gulpfile.js && cd html/themes/custom/bootstrap_subtheme_sass && rm -rf ./node_modules || exit 0",
-        "gulp": [
-            "@gulp-prepare",
-            "@gulp-build",
-            "@gulp-cleanup"
-        ],
         "post-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
             "DrupalProject\\composer\\ScriptHandler::removeUnnecessaryFiles",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,9 +17,6 @@ RUN rm -rf ./vendor && \
     composer self-update && \
     COMPOSER_MEMORY_LIMIT=-1 composer install --no-interaction --prefer-dist
 
-# Clean up previous npm installation and run new one.
-RUN COMPOSER_MEMORY_LIMIT=-1 composer gulp
-
 # Copy settings to default site location after creating it.
 RUN mkdir -m 0775 -p html/sites/default && \
     cp -a docker/settings.php docker/services.yml html/sites/default


### PR DESCRIPTION
Refs: DOC-75

Details on the ticket - but Docstore doesn't have a custom theme so shouldn't miss these commands, even if it doesn't solve the main issue.